### PR TITLE
Use old Optional, Union, type annotations in Pydantic models

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: test
 on:
   push:
     branches:
-      - workflow-testing
+      - workflow-test-fix
   pull_request:
     branches:
-      - workflow-testing
+      - workflow-test-fix
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -44,4 +44,4 @@ jobs:
         run: pip install hatch
 
       - name: Run tests
-        run: hatch run test -v
+        run: hatch run test:test -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: test
 on:
   push:
     branches:
-      - workflow-test-fix
+      - main
   pull_request:
     branches:
-      - workflow-test-fix
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/harbor_cli/commands/api/config.py
+++ b/harbor_cli/commands/api/config.py
@@ -24,7 +24,8 @@ app = typer.Typer(
 def flatten_config_response(response: ConfigurationsResponse) -> dict[str, Any]:
     """Flattens a ConfigurationsResponse object to a single level.
 
-    Example:
+    Example
+    -------
         >>> response = ConfigurationsResponse(
         ...     auth_mode=StringConfigItem(value="db_auth", editable=True),
         ... )

--- a/harbor_cli/commands/api/scanner.py
+++ b/harbor_cli/commands/api/scanner.py
@@ -29,7 +29,7 @@ def get_csanner(
         help="ID of the scanner to retrieve.",
     ),
 ) -> None:
-    """Start scanning an artifact."""
+    """Get a specific scanner."""
     logger.info(f"Fetching scanner...")
     scanner = state.run(state.client.get_scanner(scanner_id))
     render_result(scanner, ctx)

--- a/harbor_cli/output/schema.py
+++ b/harbor_cli/output/schema.py
@@ -13,8 +13,12 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 from typing import Any
+from typing import Dict
 from typing import Generic
+from typing import List
+from typing import Optional
 from typing import TypeVar
+from typing import Union
 
 from harborapi.models.base import BaseModel as HarborBaseModel
 from pydantic import BaseModel
@@ -29,14 +33,14 @@ class Schema(BaseModel, Generic[T]):
     """A schema for (de)serializing data (JSON, YAML, etc.)"""
 
     version: str = "1.0.0"  # TODO: use harborapi.models.SemVer?
-    type_: str | None = None  # should only be None if empty list
-    data: T | list[T]
+    type_: Optional[str] = None  # should only be None if empty list
+    data: Union[T, List[T]]
 
     class Config:
         extra = "allow"
 
     @root_validator
-    def set_type(cls, values: dict[str, Any]) -> dict[str, Any]:
+    def set_type(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         if values["type_"] is not None:
             return values
 

--- a/harbor_cli/state.py
+++ b/harbor_cli/state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import Awaitable
+from typing import Optional
 from typing import TypeVar
 
 from harborapi import HarborAsyncClient
@@ -26,7 +27,7 @@ class CommonOptions(BaseModel):
     verbose: bool = False
     with_stdout: bool = False
     # File
-    output_file: Path | None = None
+    output_file: Optional[Path] = None
     no_overwrite: bool = False
 
     class Config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ path = "harbor_cli/__about__.py"
 [tool.hatch.envs.default]
 dependencies = ["pytest", "pytest-cov", "mypy", "black"]
 [tool.hatch.envs.default.scripts]
-cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=harbortui --cov=tests {args}"
+test = "pytest {args}"
+cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=harbor_cli --cov=tests {args}"
 no-cov = "cov --no-cov {args}"
 
 [tool.hatch.envs.docs]

--- a/tests/data/schema_artifact.json
+++ b/tests/data/schema_artifact.json
@@ -1,0 +1,70 @@
+{
+  "version": "1.0.0",
+  "type_": "Artifact",
+  "data": {
+    "id": 1234,
+    "type": "IMAGE",
+    "media_type": "application/vnd.oci.image.config.v1+json",
+    "manifest_media_type": "application/vnd.oci.image.manifest.v1+json",
+    "project_id": 123,
+    "repository_id": 456,
+    "digest": "sha256:1234567890abcdef",
+    "size": 1234567890,
+    "icon": "sha256:abcdef1234567890",
+    "push_time": "2022-11-09T12:43:22.775000+00:00",
+    "pull_time": "2022-12-11T00:51:43.159000+00:00",
+    "extra_attrs": {
+      "architecture": "amd64",
+      "created": "2022-11-09T12:42:27.324859184Z",
+      "config": {
+        "Entrypoint": [
+          "/test-repo"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "ExposedPorts": {
+          "8080/tcp": {}
+        },
+        "Labels": {
+          "description": "Test program in the test repo",
+          "io.buildah.version": "1.26.2",
+          "no.uio.contact": "author@example.com"
+        },
+        "WorkingDir": "/"
+      },
+      "author": "author@example.com",
+      "os": "linux"
+    },
+    "annotations": {
+      "org.opencontainers.image.base.name": "harbor.example.com/library/docker.io-ubuntu:latest",
+      "org.opencontainers.image.base.digest": "sha256:d224747610648fb9f768890db4832aa6ebc92c4d17d6f6bb6a7a37ddb3c02b56"
+    },
+    "references": null,
+    "tags": [
+      {
+        "id": 21934,
+        "repository_id": 512,
+        "artifact_id": 40519,
+        "name": "latest",
+        "push_time": "2022-11-09T12:43:22.792000+00:00",
+        "pull_time": "2022-11-09T12:57:05.088000+00:00",
+        "immutable": false,
+        "signed": false
+      }
+    ],
+    "addition_links": {
+      "vulnerabilities": {
+        "absolute": false,
+        "href": "/api/v2.0/projects/test-project/repositories/test-repo/artifacts/sha256:1234567890abcdef/additions/vulnerabilities"
+      },
+      "build_history": {
+        "absolute": false,
+        "href": "/api/v2.0/projects/test-project/repositories/test-repo/artifacts/sha256:1234567890abcdef/additions/build_history"
+      }
+    },
+    "labels": null,
+    "scan_overview": null,
+    "accessories": null
+  }
+}

--- a/tests/data/schema_artifactinfo.json
+++ b/tests/data/schema_artifactinfo.json
@@ -1,0 +1,117 @@
+{
+  "version": "1.0.0",
+  "type_": "ArtifactInfo",
+  "data": {
+    "artifact": {
+      "id": 1234,
+      "type": "IMAGE",
+      "media_type": "application/vnd.oci.image.config.v1+json",
+      "manifest_media_type": "application/vnd.oci.image.manifest.v1+json",
+      "project_id": 123,
+      "repository_id": 456,
+      "digest": "sha256:1234567890abcdef",
+      "size": 1234567890,
+      "icon": "sha256:abcdef1234567890",
+      "push_time": "2022-11-09T12:43:22.775000+00:00",
+      "pull_time": "2022-12-11T00:51:43.159000+00:00",
+      "extra_attrs": {
+        "architecture": "amd64",
+        "created": "2022-11-09T12:42:27.324859184Z",
+        "config": {
+          "Entrypoint": [
+            "/test-repo"
+          ],
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          ],
+          "ExposedPorts": {
+            "8080/tcp": {}
+          },
+          "Labels": {
+            "description": "Test program in the test repo",
+            "io.buildah.version": "1.26.2",
+            "no.uio.contact": "author@example.com"
+          },
+          "WorkingDir": "/"
+        },
+        "author": "author@example.com",
+        "os": "linux"
+      },
+      "annotations": {
+        "org.opencontainers.image.base.name": "harbor.example.com/library/docker.io-ubuntu:latest",
+        "org.opencontainers.image.base.digest": "sha256:d224747610648fb9f768890db4832aa6ebc92c4d17d6f6bb6a7a37ddb3c02b56"
+      },
+      "references": null,
+      "tags": [
+        {
+          "id": 21934,
+          "repository_id": 512,
+          "artifact_id": 40519,
+          "name": "latest",
+          "push_time": "2022-11-09T12:43:22.792000+00:00",
+          "pull_time": "2022-11-09T12:57:05.088000+00:00",
+          "immutable": false,
+          "signed": false
+        }
+      ],
+      "addition_links": {
+        "vulnerabilities": {
+          "absolute": false,
+          "href": "/api/v2.0/projects/test-project/repositories/test-repo/artifacts/sha256:1234567890abcdef/additions/vulnerabilities"
+        },
+        "build_history": {
+          "absolute": false,
+          "href": "/api/v2.0/projects/test-project/repositories/test-repo/artifacts/sha256:1234567890abcdef/additions/build_history"
+        }
+      },
+      "labels": null,
+      "scan_overview": {
+        "report_id": "5451a7d6-f369-4043-8987-42a9bdb8e66e",
+        "scan_status": "Success",
+        "severity": "High",
+        "duration": 2421,
+        "summary": {
+          "total": 18,
+          "fixable": 3,
+          "critical": 0,
+          "high": 1,
+          "medium": 3,
+          "low": 13,
+          "summary": {
+            "High": 1,
+            "Low": 13,
+            "Medium": 3,
+            "Unknown": 1
+          },
+          "Unknown": 1
+        },
+        "start_time": "2022-12-11T00:11:27+00:00",
+        "end_time": "2022-12-11T00:51:48+00:00",
+        "complete_percent": 100,
+        "scanner": {
+          "name": "Trivy",
+          "vendor": "Aqua Security",
+          "version": "v0.29.2"
+        }
+      },
+      "accessories": null
+    },
+    "repository": {
+      "id": 456,
+      "project_id": 123,
+      "name": "test-project/test-repo",
+      "description": null,
+      "artifact_count": 100,
+      "pull_count": 999,
+      "creation_time": "2022-01-01T01:02:03.000000+00:00",
+      "update_time": "2022-02-02T01:02:03.000000+00:00"
+    },
+    "report": {
+      "generated_at": null,
+      "artifact": null,
+      "scanner": null,
+      "severity": "Unknown",
+      "vulnerabilities": []
+    }
+  }
+}

--- a/tests/data/schema_artifactinfo_list.json
+++ b/tests/data/schema_artifactinfo_list.json
@@ -1,0 +1,119 @@
+{
+  "version": "1.0.0",
+  "type_": "ArtifactInfo",
+  "data": [
+    {
+      "artifact": {
+        "id": 1234,
+        "type": "IMAGE",
+        "media_type": "application/vnd.oci.image.config.v1+json",
+        "manifest_media_type": "application/vnd.oci.image.manifest.v1+json",
+        "project_id": 123,
+        "repository_id": 456,
+        "digest": "sha256:1234567890abcdef",
+        "size": 1234567890,
+        "icon": "sha256:abcdef1234567890",
+        "push_time": "2022-11-09T12:43:22.775000+00:00",
+        "pull_time": "2022-12-11T00:51:43.159000+00:00",
+        "extra_attrs": {
+          "architecture": "amd64",
+          "created": "2022-11-09T12:42:27.324859184Z",
+          "config": {
+            "Entrypoint": [
+              "/test-repo"
+            ],
+            "Env": [
+              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ],
+            "ExposedPorts": {
+              "8080/tcp": {}
+            },
+            "Labels": {
+              "description": "Test program in the test repo",
+              "io.buildah.version": "1.26.2",
+              "no.uio.contact": "author@example.com"
+            },
+            "WorkingDir": "/"
+          },
+          "author": "author@example.com",
+          "os": "linux"
+        },
+        "annotations": {
+          "org.opencontainers.image.base.name": "harbor.example.com/library/docker.io-ubuntu:latest",
+          "org.opencontainers.image.base.digest": "sha256:d224747610648fb9f768890db4832aa6ebc92c4d17d6f6bb6a7a37ddb3c02b56"
+        },
+        "references": null,
+        "tags": [
+          {
+            "id": 21934,
+            "repository_id": 512,
+            "artifact_id": 40519,
+            "name": "latest",
+            "push_time": "2022-11-09T12:43:22.792000+00:00",
+            "pull_time": "2022-11-09T12:57:05.088000+00:00",
+            "immutable": false,
+            "signed": false
+          }
+        ],
+        "addition_links": {
+          "vulnerabilities": {
+            "absolute": false,
+            "href": "/api/v2.0/projects/test-project/repositories/test-repo/artifacts/sha256:1234567890abcdef/additions/vulnerabilities"
+          },
+          "build_history": {
+            "absolute": false,
+            "href": "/api/v2.0/projects/test-project/repositories/test-repo/artifacts/sha256:1234567890abcdef/additions/build_history"
+          }
+        },
+        "labels": null,
+        "scan_overview": {
+          "report_id": "5451a7d6-f369-4043-8987-42a9bdb8e66e",
+          "scan_status": "Success",
+          "severity": "High",
+          "duration": 2421,
+          "summary": {
+            "total": 18,
+            "fixable": 3,
+            "critical": 0,
+            "high": 1,
+            "medium": 3,
+            "low": 13,
+            "summary": {
+              "High": 1,
+              "Low": 13,
+              "Medium": 3,
+              "Unknown": 1
+            },
+            "Unknown": 1
+          },
+          "start_time": "2022-12-11T00:11:27+00:00",
+          "end_time": "2022-12-11T00:51:48+00:00",
+          "complete_percent": 100,
+          "scanner": {
+            "name": "Trivy",
+            "vendor": "Aqua Security",
+            "version": "v0.29.2"
+          }
+        },
+        "accessories": null
+      },
+      "repository": {
+        "id": 456,
+        "project_id": 123,
+        "name": "test-project/test-repo",
+        "description": null,
+        "artifact_count": 100,
+        "pull_count": 999,
+        "creation_time": "2022-01-01T01:02:03.000000+00:00",
+        "update_time": "2022-02-02T01:02:03.000000+00:00"
+      },
+      "report": {
+        "generated_at": null,
+        "artifact": null,
+        "scanner": null,
+        "severity": "Unknown",
+        "vulnerabilities": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
For some reason the tests fail on Python 3.8 and 3.9 even with `from __future__ import annotations` at the top of each file. I was under the impression you could use the `|` operator for type annotations as long as you imported annotations, but apparently that only goes for using built-ins as generics.

This only affects Pydantic models, but it's a change that should probably made across the entire project, because we now have 2 separate dependencies that use the old-style annotations (Pydantic & Typer). So until that is resolved (or when we drop 3.8 and 3.9), we have to continue using the old style of annotations.