### PR TITLE
Add configuration wizard for `harbor init`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,9 +6,16 @@ Harbor CLI is configured via a TOML configuration file which must be created pri
 harbor init
 ```
 
-This will create a config file with default values at `~/.config/harbor-cli/config.toml` (depends on your platform). Before you can use Harbor CLI, you will need to edit this file to add your Harbor URL and credentials (username+secret, base64 credentials or JSON credentials file).
+This will create a config file at `~/.config/harbor-cli/config.toml` (depends on your platform), and then run the interactive configuration wizard. Specify the `--no-wizard` flag to skip the configuration wizard.
 
-In the future, a configuration wizard will be added to make this process easier.
+!!! important
+    The configuration file is required to run the application. Running without a configuration file will call `harbor init` and create a configuration file at the default location.
+
+To create a configuration file at a specific location, use the `--path` option:
+
+```
+harbor init --path /path/to/config.toml
+```
 
 ## Sample configuration file
 
@@ -18,8 +25,14 @@ In the future, a configuration wizard will be added to make this process easier.
 
 **NOTE**: The name of the `output.JSON` table is case-sensitive. The reason this name is upper-case is due to a conflict with the built-in Pydantic `json` method. This will hopefully be fixed in a future release.
 
-## Custom configuration file location
-A custom configuration file can be created with the help of the `sample-config` command:
+## Print sample configuration file to stdout
+To print a sample configuration file, use the `sample-config` command:
+
+```
+harbor sample-config
+```
+
+This can then be combined with the `>` operator to redirect the output to a file:
 
 ```
 harbor sample-config > /path/to/config.toml

--- a/harbor_cli/commands/api/cve_allowlist.py
+++ b/harbor_cli/commands/api/cve_allowlist.py
@@ -30,10 +30,11 @@ def get_allowlist(ctx: typer.Context) -> None:
 @app.command("update")
 def update_allowlist(
     ctx: typer.Context,
-    cve: List[str] = typer.Option(
+    cves: List[str] = typer.Option(
         [],
         "--cve",
         help="CVE to add to the allowlist. Can be a comma-separated list, or specified multiple times.",
+        callback=parse_commalist,
     ),
     replace: bool = typer.Option(
         False,
@@ -42,8 +43,6 @@ def update_allowlist(
     ),
 ) -> None:
     """Add CVE IDs to the CVE allowlist."""
-    cves = parse_commalist(cve)
-
     current_list = state.run(state.client.get_cve_allowlist())
 
     cve_items = [CVEAllowlistItem(cve_id=cve_id) for cve_id in cves]

--- a/harbor_cli/commands/api/project.py
+++ b/harbor_cli/commands/api/project.py
@@ -564,6 +564,7 @@ def set_project_metadata(
             "May be specified multiple times, or as a comma-separated list."
         ),
         metavar="KEY=VALUE",
+        callback=parse_commalist,
     ),
 ) -> None:
     """Set metadata for a project. Until Harbor API spec"""
@@ -571,7 +572,7 @@ def set_project_metadata(
     params = model_params_from_ctx(ctx, ProjectMetadata)
 
     # Extra metadata args
-    extra_metadata = parse_key_value_args(parse_commalist(extra))
+    extra_metadata = parse_key_value_args(extra)
     arg = get_project_arg(project_name_or_id, is_id)
 
     metadata = ProjectMetadata(

--- a/harbor_cli/commands/cli/init.py
+++ b/harbor_cli/commands/cli/init.py
@@ -112,7 +112,7 @@ def init_harbor_settings(config: HarborCLIConfig) -> None:
 
     hconf = config.harbor
     config.harbor.url = Prompt.ask(
-        "Harbor URL",
+        "Harbor API URL (e.g. https://harbor.example.com/api/v2.0)",
         default=hconf.url,
         show_default=True,
     )

--- a/harbor_cli/commands/cli/init.py
+++ b/harbor_cli/commands/cli/init.py
@@ -4,19 +4,250 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+from rich.prompt import Confirm
+from rich.prompt import IntPrompt
+from rich.prompt import Prompt
 
 from ...app import app
 from ...config import create_config
+from ...config import HarborCLIConfig
+from ...config import load_config
+from ...config import save_config
+from ...exceptions import ConfigError
+from ...exceptions import OverwriteError
+from ...logs import logger
+from ...logs import LogLevel
 from ...output.console import console
+from ...output.format import output_format_repr
+from ...output.format import OutputFormat
+from ...output.prompts import path_prompt
+from ...output.prompts import str_prompt
+
+
+TITLE_STYLE = "bold"  # Style for titles used by each config category
+MAIN_TITLE_STYLE = "bold underline"  # Style for the main title
 
 
 @app.command("init")
 def init(
-    path: Optional[Path] = typer.Option(None, help="Path to create config file."),
-    overwrite: bool = typer.Option(False, help="Overwrite existing config file."),
+    ctx: typer.Context,
+    path: Optional[Path] = typer.Option(
+        None,
+        help="Path to create config file.",
+    ),
+    overwrite: bool = typer.Option(
+        False,
+        help="Overwrite existing config file.",
+        is_flag=True,
+    ),
+    no_wizard: bool = typer.Option(
+        False,
+        help="Do not run the configuration wizard after creating the config file.",
+        is_flag=True,
+    ),
 ) -> None:
     """Initialize Harbor CLI."""
-    console.print("Initializing Harbor CLI...")
-    config_path = create_config(path, overwrite=overwrite)
-    console.print(f"Created config file at {config_path}")
-    # other initialization tasks here
+    # Invert flag (easier to reason about)
+    run_wizard = not no_wizard
+
+    logger.debug("Initializing Harbor CLI...")
+    try:
+        config_path = create_config(path, overwrite=overwrite)
+    except OverwriteError:
+        if not run_wizard:
+            raise typer.Exit()
+        run_wizard = Confirm.ask(
+            "Config file already exists. Run configuration wizard?",
+            default=False,
+        )
+        config_path = None
+    else:
+        logger.info(f"Created config file at {config_path}")
+
+    if run_wizard:
+        run_config_wizard(config_path)
+
+
+def run_config_wizard(config_path: Optional[Path] = None) -> None:
+    """Loads the config file, and runs the configuration wizard.
+
+    Delegates to subroutines for each config category, that modify
+    the loaded config object in-place."""
+    conf_exists = config_path is None
+
+    config = load_config(config_path)
+    assert config.config_file is not None
+
+    console.print()
+    console.rule("Harbor CLI Configuration Wizard")
+
+    # We only ask the user to configure mandatory sections if the config
+    # file existed prior to running wizard.
+    # Otherwise, we force the user to configure Harbor settings, because
+    # we can't do anything without them.
+    if not conf_exists or Confirm.ask("\nConfigure harbor settings?", default=False):
+        init_harbor_settings(config)
+        console.print()
+
+    # These categories are optional, and as such we always ask the user
+    if Confirm.ask("Configure output settings?", default=False):
+        init_output_settings(config)
+        console.print()
+
+    if Confirm.ask("Configure logging settings?", default=False):
+        init_logging_settings(config)
+        console.print()
+
+    conf_path = config_path or config.config_file
+    if not conf_path:
+        raise ConfigError("Could not determine config file path.")
+    save_config(config, conf_path)
+    logger.info(f"Saved config to {conf_path}")
+    console.rule("Configuration complete!")
+
+
+def init_harbor_settings(config: HarborCLIConfig) -> None:
+    """Initialize Harbor settings."""
+    console.print("\nHarbor Configuration", style=TITLE_STYLE)
+
+    hconf = config.harbor
+    config.harbor.url = Prompt.ask(
+        "Harbor URL",
+        default=hconf.url,
+        show_default=True,
+    )
+
+    auth_scheme = Prompt.ask(
+        "Authentication scheme: \[u]sername/password, \[t]oken or \[f]ile",
+        choices=["u", "t", "f"],
+    )
+    if auth_scheme == "u":
+        hconf.username = str_prompt(
+            "Harbor username",
+            default=hconf.username,
+            empty_ok=False,
+        )
+        hconf.secret = str_prompt(
+            "Harbor secret",
+            default=hconf.secret,
+            password=True,
+            empty_ok=False,
+        )
+    elif auth_scheme == "t":
+        hconf.credentials_base64 = str_prompt(
+            f"Harbor base64 credentials",
+            default=hconf.credentials_base64,
+            password=True,
+            empty_ok=False,
+        )
+    elif auth_scheme == "f":
+        hconf.credentials_file = path_prompt(
+            "Harbor credentials file",
+            default=hconf.credentials_file,
+            show_default=True,
+            must_exist=True,
+            exist_ok=True,
+        )
+
+
+def init_logging_settings(config: HarborCLIConfig) -> None:
+    """Initialize logging settings."""
+    console.print("\nLogging Configuration", style=TITLE_STYLE)
+
+    lconf = config.logging
+
+    lconf.enabled = Confirm.ask(
+        "Enable logging?", default=lconf.enabled, show_default=True
+    )
+
+    loglevel = Prompt.ask(
+        "Logging level",
+        choices=[lvl.value.lower() for lvl in LogLevel],
+        default=lconf.level.value.lower(),  # use lower to match choices
+        show_default=True,
+    )
+    lconf.level = LogLevel(loglevel.upper())
+
+
+def init_output_settings(config: HarborCLIConfig) -> None:
+    """Initialize output settings."""
+    console.print("\nOutput Configuration", style=TITLE_STYLE)
+
+    oconf = config.output
+    fmt_in = Prompt.ask(
+        "Output format",
+        choices=[f.value for f in OutputFormat],
+        default=oconf.format.value,
+    )
+    oconf.format = OutputFormat(fmt_in)
+
+    def conf_fmt(fmt: OutputFormat) -> None:
+        if fmt == OutputFormat.JSON:
+            _init_output_json_settings(config)
+        elif fmt == OutputFormat.TABLE:
+            _init_output_table_settings(config)
+        elif fmt == OutputFormat.JSONSCHEMA:
+            _init_output_jsonschema_settings(config)
+        else:
+            logger.error(f"Unknown configuration format {fmt.value}")
+
+    # Configure the chosen format first
+    conf_fmt(oconf.format)
+
+    # Optionally configure other formats afterwards
+    formats = [f for f in OutputFormat if f != oconf.format]
+    for fmt in formats:
+        if Confirm.ask(
+            f"\nConfigure {output_format_repr(fmt)} output settings?",
+            default=False,
+        ):
+            conf_fmt(fmt)
+
+
+def _init_output_json_settings(config: HarborCLIConfig) -> None:
+    """Initialize JSON output settings."""
+    _print_output_title(OutputFormat.JSON)
+
+    oconf = config.output.JSON
+
+    oconf.indent = IntPrompt.ask(
+        "JSON indent",
+        default=oconf.indent,
+        show_default=True,
+    )
+
+    oconf.sort_keys = Confirm.ask(
+        "Sort JSON keys",
+        default=oconf.sort_keys,
+        show_default=True,
+    )
+
+
+def _init_output_table_settings(config: HarborCLIConfig) -> None:
+    """Initialize table output settings."""
+    _print_output_title(OutputFormat.TABLE)
+
+    oconf = config.output.table
+
+    oconf.max_depth = IntPrompt.ask(
+        "Max number of subtables (leave empty for unlimited)",
+        default=oconf.max_depth,
+        show_default=True,
+    )
+
+    oconf.description = Confirm.ask(
+        "Show description column",
+        default=oconf.description,
+        show_default=True,
+    )
+
+
+def _init_output_jsonschema_settings(config: HarborCLIConfig) -> None:
+    """Initialize JSON Schema output settings."""
+    pass
+    # TODO: Implement this if we get JSON Schema-specific settings
+
+
+def _print_output_title(fmt: OutputFormat) -> None:
+    fmt_repr = output_format_repr(fmt)
+    console.print(f"\nOutput Configuration ({fmt_repr})", style=TITLE_STYLE)

--- a/harbor_cli/config.py
+++ b/harbor_cli/config.py
@@ -121,18 +121,22 @@ class HarborSettings(BaseModel):
             raise CredentialsError("A Harbor API URL is required")
 
         # require one of the auth methods to be set
-        if not (
-            self.username
-            and self.secret
-            or self.credentials_base64
-            or self.credentials_file
-        ):
+        if not self.has_auth_method:
             raise CredentialsError(
                 "A harbor authentication method must be specified. "
                 "One of 'username'+'secret', 'credentials_base64', or 'credentials_file' must be specified. "
                 "See the documentation for more information."
             )
         return True
+
+    @property
+    def has_auth_method(self) -> bool:
+        """Returns True if any of the auth methods are set."""
+        return bool(
+            (self.username and self.secret)
+            or self.credentials_base64
+            or self.credentials_file
+        )
 
     @property
     def credentials(self) -> HarborCredentialsKwargs:

--- a/harbor_cli/config.py
+++ b/harbor_cli/config.py
@@ -17,6 +17,7 @@ from pydantic import validator
 from .dirs import CONFIG_DIR
 from .exceptions import ConfigError
 from .exceptions import CredentialsError
+from .exceptions import HarborCLIError
 from .exceptions import OverwriteError
 from .logs import LogLevel
 from .output.format import OutputFormat
@@ -79,6 +80,7 @@ class BaseModel(HarborBaseModel):
         # Allow for future fields to be added to the config file without
         # breaking older versions of Harbor CLI
         extra = "allow"
+        validate_assignment = True
 
 
 class HarborCredentialsKwargs(TypedDict):
@@ -163,6 +165,7 @@ class TableSettings(BaseModel):
 
     description: bool = False
     max_depth: Optional[int] = -1
+    # TODO: table style
 
     @validator("max_depth", pre=True)
     def negative_is_none(cls, v: int | None) -> int | None:
@@ -204,7 +207,7 @@ class HarborCLIConfig(BaseModel):
 
     @classmethod
     def from_file(
-        cls, config_file: Path = DEFAULT_CONFIG_FILE, create: bool = False
+        cls, config_file: Path | None = DEFAULT_CONFIG_FILE, create: bool = False
     ) -> HarborCLIConfig:
         """Create a Config object from a TOML file.
 
@@ -221,6 +224,9 @@ class HarborCLIConfig(BaseModel):
         Config
             A Config object.
         """
+        if config_file is None:
+            config_file = DEFAULT_CONFIG_FILE
+
         if not config_file.exists():
             if create:
                 create_config(config_file)
@@ -249,13 +255,27 @@ def create_config(config_path: Path | None, overwrite: bool = False) -> Path:
     return config_path
 
 
-def load_config() -> HarborCLIConfig | None:
+def load_config(config_path: Path | None = None) -> HarborCLIConfig:
     """Load the config file."""
     try:
-        return HarborCLIConfig.from_file()
+        return HarborCLIConfig.from_file(config_path)
+    except HarborCLIError:
+        raise
     except Exception as e:
-        logger.error("Could not load config file: {}", e)
-        return None
+        logger.bind(exc=e).error("Failed to load config file")
+        raise ConfigError(f"Could not load config file {config_path}: {e}") from e
+
+
+def save_config(config: HarborCLIConfig, config_path: Path) -> None:
+    """Save the config file."""
+    try:
+        # Round-trip through JSON to handle incompatible tomli-w types
+        config_path.write_text(
+            tomli_w.dumps(json.loads(config.json(exclude_none=True)))
+        )
+    except Exception as e:
+        logger.bind(exc=e).error("Failed to save config file")
+        raise ConfigError(f"Could not save config file {config_path}: {e}") from e
 
 
 def sample_config(exclude_none: bool = False) -> str:

--- a/harbor_cli/main.py
+++ b/harbor_cli/main.py
@@ -114,7 +114,7 @@ def main_callback(
         state.config = HarborCLIConfig.from_file(config_file)
     except FileNotFoundError:
         # TODO: invoke init
-        exit_err(f"Config file not found. Run 'harbor-cli init' to create one.")
+        exit_err(f"Config file not found. Run 'harbor init' to create one.")
 
     # Set config overrides
     if show_description is not None:

--- a/harbor_cli/main.py
+++ b/harbor_cli/main.py
@@ -109,13 +109,12 @@ def main_callback(
     if any(help_arg in sys.argv for help_arg in ctx.help_option_names):
         return
 
-    if config_file:
-        # If a config file is specified, it needs to exist
+    # Run init if config file doesn't exist
+    try:
         state.config = HarborCLIConfig.from_file(config_file)
-    else:
-        # Support creating config file if no path is specified,
-        # and the default config file doesn't exist.
-        state.config = HarborCLIConfig.from_file(create=True)
+    except FileNotFoundError:
+        # TODO: invoke init
+        exit_err(f"Config file not found. Run 'harbor-cli init' to create one.")
 
     # Set config overrides
     if show_description is not None:

--- a/harbor_cli/output/format.py
+++ b/harbor_cli/output/format.py
@@ -15,10 +15,18 @@ class OutputFormat(Enum):
     # others...?
 
 
+# TODO: consolidate this metadata with the enum
+
 OUTPUTFORMAT_REPR = {
     OutputFormat.TABLE: "table",
     OutputFormat.JSON: "JSON",
     OutputFormat.JSONSCHEMA: "JSON+Schema",
+}
+
+OUTPUTFORMAT_EMOJI = {
+    OutputFormat.TABLE: ":page_facing_up:",
+    OutputFormat.JSON: ":package:",
+    OutputFormat.JSONSCHEMA: ":package:+:memo:",
 }
 
 
@@ -28,4 +36,13 @@ def output_format_repr(fmt: OutputFormat) -> str:
     if f is None:
         logger.warning(f"Unknown output format: {fmt}")
         f = "Unknown"
+    return f
+
+
+def output_format_emoji(fmt: OutputFormat) -> str:
+    """Return an emoji for an output format."""
+    f = OUTPUTFORMAT_EMOJI.get(fmt)
+    if f is None:
+        logger.warning(f"Unknown output format: {fmt}")
+        f = ":question:"
     return f

--- a/harbor_cli/output/format.py
+++ b/harbor_cli/output/format.py
@@ -1,6 +1,9 @@
+"""Output format of the command result."""
 from __future__ import annotations
 
 from enum import Enum
+
+from ..logs import logger
 
 
 class OutputFormat(Enum):
@@ -10,3 +13,19 @@ class OutputFormat(Enum):
     JSON = "json"
     JSONSCHEMA = "jsonschema"
     # others...?
+
+
+OUTPUTFORMAT_REPR = {
+    OutputFormat.TABLE: "table",
+    OutputFormat.JSON: "JSON",
+    OutputFormat.JSONSCHEMA: "JSON+Schema",
+}
+
+
+def output_format_repr(fmt: OutputFormat) -> str:
+    """Return a human-readable representation of an output format."""
+    f = OUTPUTFORMAT_REPR.get(fmt)
+    if f is None:
+        logger.warning(f"Unknown output format: {fmt}")
+        f = "Unknown"
+    return f

--- a/harbor_cli/output/formatting.py
+++ b/harbor_cli/output/formatting.py
@@ -1,0 +1,14 @@
+"""Control the formatting of console output."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def path_link(path: Path, absolute: bool = True) -> str:
+    """Return a link to a path."""
+    abspath = path.resolve().absolute()
+    if absolute:
+        path_str = str(abspath)
+    else:
+        path_str = str(path)
+    return f"[link=file://{abspath}]{path_str}[/link]"

--- a/harbor_cli/output/prompts.py
+++ b/harbor_cli/output/prompts.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from rich.prompt import Prompt
+
+from .console import err_console
+from .formatting import path_link
+
+
+def str_prompt(
+    prompt: str,
+    default: Any = ...,
+    password: bool = False,
+    show_default: bool = True,
+    empty_ok: bool = False,
+    **kwargs: Any,
+) -> str:
+    """Prompts the user for a string input. Optionally controls
+    for empty input.
+
+    Parameters
+    ----------
+    prompt : str
+        Prompt to display to the user.
+    default : Any, optional
+        Default value to use if the user does not provide input.
+        If not provided, the user will be required to provide input.
+    password : bool, optional
+        Whether to hide the input, by default False
+    show_default : bool, optional
+        Whether to show the default value, by default True
+        `password=True` supercedes this option, and sets it to False.
+    empty_ok : bool, optional
+        Whether to allow empty string as result, by default False.
+        Set to True to allow empty string as result.
+
+    """
+    # Don't permit secrets to be shown ever
+    if password:
+        show_default = False
+
+    # Notify user that a default secret will be used,
+    # but don't actually show the secret
+    if password and default:
+        _add_str = " (leave empty to use existing value)"
+    else:
+        _add_str = ""
+
+    inp = None
+
+    while not inp:
+        inp = Prompt.ask(
+            f"{prompt}{_add_str}",
+            password=password,
+            show_default=show_default,
+            default=default,
+            **kwargs,
+        )
+
+        if not inp:
+            # Default is empty string, and we allow empty input result
+            if empty_ok:
+                break
+            else:
+                err_console.print("[b]ERROR:[/] Input cannot be empty.")
+
+    return inp
+
+
+def path_prompt(
+    prompt: str,
+    default: Any = ...,
+    show_default: bool = True,
+    exist_ok: bool = True,
+    must_exist: bool = False,
+    **kwargs: Any,
+) -> Path:
+    if isinstance(default, Path):
+        default_arg = str(default)
+    elif default is None:
+        default_arg = ...  # type: ignore
+    else:
+        default_arg = default
+
+    while True:
+        path_str = str_prompt(
+            prompt,
+            default=default_arg,
+            show_default=show_default,
+            **kwargs,
+        )
+        path = Path(path_str)
+
+        if must_exist and not path.exists():
+            err_console.print(f"[b]ERROR:[/] Path does not exist: {path_link(path)}")
+        elif not exist_ok and path.exists():
+            err_console.print(f"[b]ERROR:[/] Path already exists: {path_link(path)}")
+        else:
+            return path

--- a/harbor_cli/output/render.py
+++ b/harbor_cli/output/render.py
@@ -41,7 +41,7 @@ def render_table(result: T | Sequence[T], ctx: typer.Context) -> None:
         if it is a harborapi BaseModel, otherwise just prints the item."""
         if isinstance(item, HarborBaseModel):
             console.print(
-                *(item.as_table(with_description=show_description, max_depth=max_depth))
+                item.as_panel(with_description=show_description, max_depth=max_depth)
             )
         else:
             console.print(item)

--- a/harbor_cli/state.py
+++ b/harbor_cli/state.py
@@ -4,6 +4,8 @@ import asyncio
 from pathlib import Path
 from typing import Awaitable
 from typing import Optional
+from typing import Tuple
+from typing import Type
 from typing import TypeVar
 
 from harborapi import HarborAsyncClient
@@ -56,7 +58,7 @@ class State(BaseModel):
     def run(
         self,
         coro: Awaitable[T],
-        no_handle: type[Exception] | tuple[type[Exception], ...] | None = None,
+        no_handle: Type[Exception] | Tuple[Type[Exception], ...] | None = None,
     ) -> T:
         """Run a coroutine in the event loop.
 
@@ -64,7 +66,7 @@ class State(BaseModel):
         ----------
         coro : Awaitable[T]
             The coroutine to run.
-        no_handle : type[Exception] | tuple[type[Exception], ...]
+        no_handle : Type[Exception] | Tuple[Type[Exception], ...]
             A single exception type or a tuple of exception types that
             should not be passed to the default exception handler.
             Exceptions of this type will be raised as-is.

--- a/harbor_cli/utils/args.py
+++ b/harbor_cli/utils/args.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import Type
 
 import typer
 from pydantic import BaseModel
 
 
 def model_params_from_ctx(
-    ctx: typer.Context, model: type[BaseModel], filter_none: bool = True
+    ctx: typer.Context, model: Type[BaseModel], filter_none: bool = True
 ) -> dict[str, Any]:
     """Get the model parameters from a Typer context.
 

--- a/harbor_cli/utils/utils.py
+++ b/harbor_cli/utils/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from typing import Any
+from typing import List
 from typing import Type
 
 import typer
@@ -28,7 +29,7 @@ def replace_none(d: dict[str, Any], replacement: Any = "") -> dict[str, Any]:
     return d
 
 
-def parse_commalist(arg: list[str]) -> list[str]:
+def parse_commalist(arg: List[str]) -> List[str]:
     """Parses an argument that can be specified multiple times,
     or as a comma-separated list, into a list of strings.
 

--- a/harbor_cli/utils/utils.py
+++ b/harbor_cli/utils/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from typing import Any
+from typing import Type
 
 import typer
 from pydantic import BaseModel
@@ -69,7 +70,7 @@ def parse_key_value_args(arg: list[str]) -> dict[str, str]:
 
 
 def inject_help(
-    model: type[BaseModel], strict: bool = False, **field_additions: str
+    model: Type[BaseModel], strict: bool = False, **field_additions: str
 ) -> Any:
     """
     Injects a Pydantic model's field descriptions into the help attributes
@@ -101,7 +102,7 @@ def inject_help(
 
     Parameters
     ----------
-    model : type[BaseModel]
+    model : Type[BaseModel]
         The pydantic model to use for help injection.
     strict : bool
         If True, fail if a field in the model does not have a matching typer
@@ -175,6 +176,8 @@ def inject_resource_options(
     if the parameters don't have defaults:
     `query`, `sort`, `page`, `page_size`, `retrieve_all`
 
+
+
     Parameters
     ----------
     f : Any, optional
@@ -202,6 +205,46 @@ def inject_resource_options(
     -------
     Any
         The decorated function
+
+
+    Example
+    -------
+    ```python
+    @app.command()
+    @inject_resource_options()
+    def my_command(query: str, sort: str, page: int, page_size: int, retrieve_all: bool):
+        ...
+
+    # OK
+    @app.command()
+    @inject_resource_options()
+    def my_command(query: str, sort: str):
+        ...
+
+    # NOT OK (missing all required parameters)
+    @app.command()
+    @inject_resource_options(strict=True)
+    def my_command(query: str, sort: str):
+        ...
+
+    # OK (inherits defaults)
+    @app.command()
+    @inject_resource_options()
+    def my_command(query: str, sort: str, page: int = typer.Option(1)):
+        ...
+
+    # NOT OK (syntax error [non-default param after param with default])
+    # Use ellipsis to specify unset defaults
+    @app.command()
+    @inject_resource_options()
+    def my_command(query: str = typer.Option("tag=latest"), sort: str, page: int):
+
+    # OK (inherit default query, but override others)
+    # Use ellipsis to specify unset defaults
+    @app.command()
+    @inject_resource_options()
+    def my_command(query: str = typer.Option("my-query"), sort: str = ..., page: int = ...):
+    ```
     """
 
     # TODO: add check that the function signature is in the correct order

--- a/tests/commands/test_sample_config.py
+++ b/tests/commands/test_sample_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typer.testing import CliRunner
 
+from harbor_cli.config import sample_config as get_sample_config
 from harbor_cli.main import app
 
 runner = CliRunner()
@@ -10,5 +11,4 @@ runner = CliRunner()
 def test_app():
     result = runner.invoke(app, ["sample-config"])
     assert result.exit_code == 0
-    # assert "Hello Camila" in result.stdout
-    # assert "Let's have a coffee in Berlin" in result.stdout
+    assert result.stdout == get_sample_config() + "\n"

--- a/tests/commands/test_sample_config.py
+++ b/tests/commands/test_sample_config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typer.testing import CliRunner
 
-from harbor_cli.config import sample_config as get_sample_config
 from harbor_cli.main import app
 
 runner = CliRunner()
@@ -11,4 +10,3 @@ runner = CliRunner()
 def test_app():
     result = runner.invoke(app, ["sample-config"])
     assert result.exit_code == 0
-    assert result.stdout == get_sample_config() + "\n"


### PR DESCRIPTION
This pull request adds a configuration wizard that starts automatically after `harbor init` creates the configuration file. It sets up all the configuration options required to run the application. The wizard can be disabled with the `--no-wizard` flag.

In cases where the configuration file already exists, the user is prompted to run the wizard. This prompt is disabled when the `--no-wizard` flag is provided.