### PR TITLE
Modify `update` command semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ The **third number** is the patch version (bug fixes)
 <!-- changelog follows -->
 
 <!-- ## [Unreleased] -->
+## [0.1.0](https://github.com/pederhan/harbor-cli/tree/harbor-cli-v0.1.0)
+
+### Changed
+
+- Update command semantics. See [#25](https://github.com/pederhan/harbor-cli/pull/25) and the [docs](https://pederhan.github.io/harbor-cli/usage/terminology/#actions-terminology).
+- Type of `str` parameters that take `"true"` and `"false"` have been changed to `bool`.
+  - Bool parameters for API commands now take the args `True`/`true`/`1` and `False`/`false`/`0`. Global options that override config commands are still flags in the form `--foo/--no-foo`.
+  - We use the validators defined on the models from `harborapi` to automatically convert these values to the strings `"true"`/`"false"` under the hood.
+
+### Fixed
+
+- Some commands were missing custom text for their spinner.
+
+### Removed
+
+- All `update --replace` parameters. Updates are now partial updates only.
+
 ## [0.0.1](https://github.com/pederhan/harbor-cli/tree/harbor-cli-v0.0.1) - 2023-xx-yy
 
 ### Added

--- a/docs/usage/terminology.md
+++ b/docs/usage/terminology.md
@@ -43,9 +43,9 @@ The final subcommand is the _action_ to perform on the resource, such as `create
 * `delete` - Delete a resource
     * Prompts for confirmation unless `--force` is specified.
 * `list` - List resources (optionally filtered by a query)
-* `update` - Perform a (partial) update of a resource.
+* `update` - Update a resource.
     * The default behavior is similar to a PATCH request. Performs a partial update with only the given parameters (corresponding to the resource's fields) being updated on the resource.
-    * **FLAG** `--replace`:  Replace the existing resource with a new resource using the provided data. Similar to a PUT request.
+    * The CLI diverges from the API spec here, since the spec only defines PUT operations (which replaces a given resource with a new resource definition). To improve the ergonomics of the interface for users, the CLI first retrieves the existing resource and only replaces the fields the user wants to update.
 * `set` - Set the value of a specific field on a resource.
     * Used for setting single values, such as setting default project scanner.
 * `add` - Add a value or reference to a resource to a resource

--- a/harbor_cli/__about__.py
+++ b/harbor_cli/__about__.py
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 APP_NAME = "harbor-cli"
 AUTHOR = "pederhan"

--- a/harbor_cli/commands/api/harbor_config.py
+++ b/harbor_cli/commands/api/harbor_config.py
@@ -113,6 +113,8 @@ def update_config(
     ),
     email_insecure: Optional[bool] = typer.Option(
         None,
+        "--email-insecure",
+        is_flag=False,
     ),
     email_password: Optional[str] = typer.Option(
         None,
@@ -124,6 +126,8 @@ def update_config(
     ),
     email_ssl: Optional[bool] = typer.Option(
         None,
+        "--email-ssl",
+        is_flag=False,
     ),
     email_username: Optional[str] = typer.Option(
         None,
@@ -183,6 +187,8 @@ def update_config(
     ),
     ldap_verify_cert: Optional[bool] = typer.Option(
         None,
+        "--ldap-verify-cert",
+        is_flag=False,
     ),
     ldap_group_membership_attribute: Optional[str] = typer.Option(
         None,
@@ -194,9 +200,13 @@ def update_config(
     ),
     read_only: Optional[bool] = typer.Option(
         None,
+        "--read-only",
+        is_flag=False,
     ),
     self_registration: Optional[bool] = typer.Option(
         None,
+        "--self-registration",
+        is_flag=False,
     ),
     token_expiration: Optional[int] = typer.Option(
         None,
@@ -216,6 +226,8 @@ def update_config(
     ),
     uaa_verify_cert: Optional[bool] = typer.Option(
         None,
+        "--uaa-verify-cert",
+        is_flag=False,
     ),
     http_authproxy_endpoint: Optional[str] = typer.Option(
         None,
@@ -239,9 +251,13 @@ def update_config(
     ),
     http_authproxy_verify_cert: Optional[bool] = typer.Option(
         None,
+        "--http-authproxy-verify-cert",
+        is_flag=False,
     ),
     http_authproxy_skip_search: Optional[bool] = typer.Option(
         None,
+        "--http-authproxy-skip-search",
+        is_flag=False,
     ),
     http_authproxy_server_certificate: Optional[str] = typer.Option(
         None,
@@ -281,9 +297,13 @@ def update_config(
     ),
     oidc_verify_cert: Optional[bool] = typer.Option(
         None,
+        "--oidc-verify-cert",
+        is_flag=False,
     ),
     oidc_auto_onboard: Optional[bool] = typer.Option(
         None,
+        "--oidc-auto-onboard",
+        is_flag=False,
     ),
     # TODO: fix spelling when we add alias in harborapi
     oidc_extra_redirect_parms: Optional[str] = typer.Option(
@@ -303,9 +323,13 @@ def update_config(
     ),
     notification_enable: Optional[bool] = typer.Option(
         None,
+        "--notifications",
+        is_flag=False,
     ),
     quota_per_project_enable: Optional[bool] = typer.Option(
         None,
+        "--quota-per-project",
+        is_flag=False,
     ),
     storage_per_project: Optional[int] = typer.Option(
         None,
@@ -317,6 +341,8 @@ def update_config(
     ),
     skip_audit_log_database: Optional[bool] = typer.Option(
         None,
+        "--skip-audit-log-database",
+        is_flag=False,
     ),
 ) -> None:
     """Update the configuration of Harbor."""

--- a/harbor_cli/commands/api/project.py
+++ b/harbor_cli/commands/api/project.py
@@ -143,34 +143,40 @@ def create_project(
         "--registry-id",
     ),
     # Options from the Metadata model
-    public: Optional[str] = typer.Option(
+    public: Optional[bool] = typer.Option(
         None,
         "--public",
+        is_flag=False,
     ),
-    enable_content_trust: Optional[str] = typer.Option(
+    enable_content_trust: Optional[bool] = typer.Option(
         None,
-        "--enable-content-trust",
+        "--content-trust",
+        is_flag=False,
     ),
-    enable_content_trust_cosign: Optional[str] = typer.Option(
+    enable_content_trust_cosign: Optional[bool] = typer.Option(
         None,
-        "--enable-content-trust-cosign",
+        "--content-trust-cosign",
+        is_flag=False,
     ),
-    prevent_vul: Optional[str] = typer.Option(
+    prevent_vul: Optional[bool] = typer.Option(
         None,
         "--prevent-vul",
+        is_flag=False,
     ),
     severity: Optional[str] = typer.Option(
         None,
         "--severity",
         # TODO: add custom help text? The original help text has some really broken English...
     ),
-    auto_scan: Optional[str] = typer.Option(
+    auto_scan: Optional[bool] = typer.Option(
         None,
         "--auto-scan",
+        is_flag=False,
     ),
-    reuse_sys_cve_allowlist: Optional[str] = typer.Option(
+    reuse_sys_cve_allowlist: Optional[bool] = typer.Option(
         None,
         "--reuse-sys-cve-allowlist",
+        is_flag=False,
     ),
     retention_id: Optional[str] = typer.Option(
         None,
@@ -278,19 +284,23 @@ def update_project(
     # Options from the Metadata model
     public: Optional[bool] = typer.Option(
         None,
-        "--public/--no-public",
+        "--public",
+        is_flag=False,
     ),
     enable_content_trust: Optional[bool] = typer.Option(
         None,
-        "--content-trust/--no-content-trust",
+        "--content-trust",
+        is_flag=False,
     ),
     enable_content_trust_cosign: Optional[bool] = typer.Option(
         None,
-        "--content-trust-cosign/--no-content-trust-cosign",
+        "--content-trust-cosign",
+        is_flag=False,
     ),
     prevent_vul: Optional[bool] = typer.Option(
         None,
-        "--prevent-vul/--no-prevent-vul",
+        "--prevent-vul",
+        is_flag=False,
     ),
     severity: Optional[str] = typer.Option(
         None,
@@ -299,11 +309,13 @@ def update_project(
     ),
     auto_scan: Optional[bool] = typer.Option(
         None,
-        "--auto-scan/--no-auto-scan",
+        "--auto-scan",
+        is_flag=False,
     ),
     reuse_sys_cve_allowlist: Optional[bool] = typer.Option(
         None,
-        "--reuse-sys-cve-allowlist/--no-reuse-sys-cve-allowlist",
+        "--reuse-sys-cve-allowlist",
+        is_flag=False,
     ),
     retention_id: Optional[str] = typer.Option(
         None,
@@ -541,27 +553,39 @@ def set_project_metadata(
         "--is-id",
         help="Whether the argument is a project ID or name (by default name)",
     ),
-    public: Optional[str] = typer.Option(
+    public: Optional[bool] = typer.Option(
         None,
+        "--public",
+        is_flag=False,
     ),
-    enable_content_trust: Optional[str] = typer.Option(
+    enable_content_trust: Optional[bool] = typer.Option(
         None,
+        "--content-trust",
+        is_flag=False,
     ),
-    enable_content_trust_cosign: Optional[str] = typer.Option(
+    content_trust_cosign: Optional[bool] = typer.Option(
         None,
+        "--content-trust-cosign",
+        is_flag=False,
     ),
-    prevent_vul: Optional[str] = typer.Option(
+    prevent_vul: Optional[bool] = typer.Option(
         None,
+        "--prevent-vul",
+        is_flag=False,
     ),
     severity: Optional[str] = typer.Option(
         None,
         "--severity",
     ),
-    auto_scan: Optional[str] = typer.Option(
+    auto_scan: Optional[bool] = typer.Option(
         None,
+        "--auto-scan",
+        is_flag=False,
     ),
-    reuse_sys_cve_allowlist: Optional[str] = typer.Option(
+    reuse_sys_cve_allowlist: Optional[bool] = typer.Option(
         None,
+        "--reuse-sys-cve-allowlist",
+        is_flag=False,
     ),
     retention_id: Optional[int] = typer.Option(
         None,

--- a/harbor_cli/commands/api/project.py
+++ b/harbor_cli/commands/api/project.py
@@ -11,6 +11,7 @@ from harborapi.models.models import ProjectMetadata
 from harborapi.models.models import ProjectReq
 
 from ...logs import logger
+from ...output.console import exit_err
 from ...output.render import render_result
 from ...state import state
 from ...utils import inject_help
@@ -312,8 +313,8 @@ def update_project(
     """Update project information. [bold red]UNTESTED![/]"""
     req_params = model_params_from_ctx(ctx, ProjectReq)
     metadata_params = model_params_from_ctx(ctx, ProjectMetadata)
-    if not req_params or not metadata_params:
-        raise typer.BadParameter("No parameters provided.")
+    if not req_params and not metadata_params:
+        exit_err("No parameters provided.")
 
     arg = get_project_arg(project_name_or_id, is_id)
     project = get_project(arg)
@@ -321,8 +322,18 @@ def update_project(
         project.metadata = ProjectMetadata()
 
     # Create updated models from params
-    req = create_updated_model(project, ProjectReq, ctx)
-    metadata = create_updated_model(project.metadata, ProjectMetadata, ctx)
+    req = create_updated_model(
+        project,
+        ProjectReq,
+        ctx,
+        empty_ok=True,
+    )
+    metadata = create_updated_model(
+        project.metadata,
+        ProjectMetadata,
+        ctx,
+        empty_ok=True,
+    )
     req.metadata = metadata
 
     state.run(state.client.update_project(arg, req), f"Updating project...")

--- a/harbor_cli/commands/api/registry.py
+++ b/harbor_cli/commands/api/registry.py
@@ -224,6 +224,8 @@ def check_registry_status(
     ),
     insecure: Optional[bool] = typer.Option(
         None,
+        "--insecure",
+        is_flag=False,
     ),
 ) -> None:
     """Ping a registry to see if it's reachable."""

--- a/harbor_cli/commands/api/replication.py
+++ b/harbor_cli/commands/api/replication.py
@@ -229,9 +229,21 @@ def create_replication_policy(
         "--filter-resource",
         help="Filter the resource type to replicate.",
     ),
-    replicate_deletion: Optional[bool] = typer.Option(None),
-    override: Optional[bool] = typer.Option(None),
-    enabled: Optional[bool] = typer.Option(None),
+    replicate_deletion: Optional[bool] = typer.Option(
+        None,
+        "--replicate-deletion",
+        is_flag=False,
+    ),
+    override: Optional[bool] = typer.Option(
+        None,
+        "--override",
+        is_flag=False,
+    ),
+    enabled: Optional[bool] = typer.Option(
+        None,
+        "--enabled",
+        is_flag=False,
+    ),
     speed: Optional[int] = typer.Option(None, "--speed-limit"),
 ) -> None:
     """Create a replication policy."""

--- a/harbor_cli/commands/api/repository.py
+++ b/harbor_cli/commands/api/repository.py
@@ -20,9 +20,16 @@ app = typer.Typer(
 )
 
 
+def get_repository(project: str, repository_name: str) -> Repository:
+    return state.run(
+        state.client.get_repository(project, repository_name),
+        "Fetching repository...",
+    )
+
+
 # HarborAsyncClient.get_repository()
 @app.command("get", no_args_is_help=True)
-def get_repo(
+def get_reposity_command(
     ctx: typer.Context,
     project: str = typer.Argument(
         ...,
@@ -34,16 +41,8 @@ def get_repo(
     ),
 ) -> None:
     """Fetch a repository."""
-
     # TODO: accept single arg like in `harbor-cli artifact get`?
-
-    repo = state.run(
-        state.client.get_repository(
-            project,
-            repository,
-        ),
-        "Fetching repository...",
-    )
+    repo = get_repository(project, repository)
     render_result(repo, ctx)
 
 
@@ -89,11 +88,11 @@ def update_repository(
     ctx: typer.Context,
     project: str = typer.Argument(
         ...,
-        help="Name of the project the repository belongs to.",
+        help="Project name of repository to update.",
     ),
     repository: str = typer.Argument(
         ...,
-        help="Name of the repository to get.",
+        help="Name of the repository to update.",
     ),
     description: Optional[str] = typer.Option(None),
 ) -> None:
@@ -101,13 +100,9 @@ def update_repository(
 
     As of now, only the description can be updated (if the Web UI is to be trusted).
     """
-    state.run(
-        state.client.update_repository(
-            project,
-            repository,
-            Repository(description=description),
-        )
-    )
+    repo = get_repository(project, repository)
+    repo.description = description
+    state.run(state.client.update_repository(project, repository, repo))
     logger.info(f"Updated {project}/{repository}.")
 
 

--- a/harbor_cli/commands/api/scanner.py
+++ b/harbor_cli/commands/api/scanner.py
@@ -6,7 +6,6 @@ import typer
 from harborapi.models.models import ScannerRegistration
 from harborapi.models.models import ScannerRegistrationReq
 
-from ...exceptions import HarborCLIError
 from ...logs import logger
 from ...output.render import render_result
 from ...state import state
@@ -39,95 +38,6 @@ def get_csanner(
     """Get a specific scanner."""
     scanner = get_scanner(scanner_id)
     render_result(scanner, ctx)
-
-
-@inject_help(ScannerRegistrationReq)
-def _do_handle_scanner_modification(
-    ctx: typer.Context,
-    scanner_id: Optional[str] = typer.Argument(
-        None,
-        help="ID of the scanner to modify. Ignored for create.",
-    ),
-    name: str = typer.Option(
-        "",
-        "--name",
-    ),
-    url: str = typer.Option(
-        "",
-        "--url",
-    ),
-    description: Optional[str] = typer.Option(
-        None,
-        "--description",
-    ),
-    auth: Optional[str] = typer.Option(
-        None,
-        "--auth",
-    ),
-    access_credential: Optional[str] = typer.Option(
-        None,
-        "--access-credential",
-    ),
-    skip_cert_verify: Optional[bool] = typer.Option(
-        None,
-    ),
-    use_internal_addr: Optional[bool] = typer.Option(
-        None,
-    ),
-    disabled: bool = typer.Option(
-        False,
-        "--disabled",
-    ),
-) -> None:
-    # When creating, we require
-    if ctx.command.name == "create":
-        if scanner_id is not None:
-            raise typer.BadParameter("Unexpected argument SCANNER_ID")
-        if name == "":
-            raise typer.BadParameter("Missing required argument --name")
-        if url == "":
-            raise typer.BadParameter("Missing required argument --url")
-    elif ctx.command.name == "update":
-        if scanner_id is None:
-            raise typer.BadParameter("Missing required argument SCANNER_ID")
-
-    req = ScannerRegistrationReq(
-        name=name,
-        description=description,
-        url=url,
-        auth=auth,
-        access_credential=access_credential,
-        skip_cert_verify=skip_cert_verify,
-        use_internal_addr=use_internal_addr,
-        disabled=disabled,
-    )
-    # TODO: investigate which parameters the `parameters` field takes
-
-    # TODO: fix this shitshow
-    if ctx.command.name == "create":
-        location = state.run(state.client.create_scanner(req), "Creating scanner...")
-        render_result(location, ctx)
-        logger.info(f"Scanner created: {location}.")
-    elif ctx.command.name == "update":
-        assert scanner_id is not None  # type: ignore # mypy doesn't understand that we have checked this already
-        existing_scanner = state.run(
-            state.client.get_scanner(scanner_id), "Fetching current scanner..."
-        )
-        if existing_scanner is None:
-            raise HarborCLIError(f"Scanner with ID {scanner_id!r} does not exist.")
-
-        # Cast existing scanner to dict, update it with the new values and parse it back to a ScannerRegistrationReq
-        d = existing_scanner.dict()
-        d.update(req.dict(exclude_none=True, exclude_unset=True))
-        req = ScannerRegistrationReq.parse_obj(d)
-
-        state.run(
-            state.client.update_scanner(scanner_id, req),
-            "Updating scanner...",
-        )
-        logger.info(f"Scanner with ID {scanner_id!r} updated.")
-    else:
-        raise HarborCLIError(f"Unknown command {ctx.command.name}")
 
 
 # HarborAsyncClient.create_scanner()

--- a/harbor_cli/commands/api/scanner.py
+++ b/harbor_cli/commands/api/scanner.py
@@ -65,13 +65,18 @@ def create_scanner(
     ),
     skip_cert_verify: Optional[bool] = typer.Option(
         None,
+        "--skip-cert-verify",
+        is_flag=False,
     ),
     use_internal_addr: Optional[bool] = typer.Option(
         None,
+        "--use-internal-addr",
+        is_flag=False,
     ),
     disabled: Optional[bool] = typer.Option(
         None,
-        "--disabled/--enabled",
+        "--disabled",
+        is_flag=False,
     ),
 ) -> None:
     """Create a new scanner."""
@@ -110,13 +115,18 @@ def update_scanner(
     ),
     skip_cert_verify: Optional[bool] = typer.Option(
         None,
+        "--skip-cert-verify",
+        is_flag=False,
     ),
     use_internal_addr: Optional[bool] = typer.Option(
         None,
+        "--use-internal-addr",
+        is_flag=False,
     ),
     disabled: Optional[bool] = typer.Option(
         False,
-        "--disabled/--enabled",
+        "--disabled",
+        is_flag=False,
     ),
 ) -> None:
     """Update a scanner."""

--- a/harbor_cli/utils/args.py
+++ b/harbor_cli/utils/args.py
@@ -108,12 +108,10 @@ def create_updated_model(
         exit_err("No parameters provided to update")
 
     # Cast existing model to dict, update it with the new values
-    d = existing.dict(include=None if extra else existing.__fields_set__)
+    d = existing.dict(include=None if extra else set(new.__fields__))
     d.update(params)
 
-    # Parse it back to the new model
-    new_model = new.parse_obj(d)
-    return new_model
+    return new.parse_obj(d)
 
 
 def parse_harbor_bool_arg(arg: str | None) -> bool | None:

--- a/harbor_cli/utils/args.py
+++ b/harbor_cli/utils/args.py
@@ -31,6 +31,8 @@ def model_params_from_ctx(
     ----------
     ctx : typer.Context
         The Typer context.
+    model : Type[BaseModel]
+        The model to get the parameters for.
     filter_none : bool
         Whether to filter out None values, by default True
 
@@ -42,7 +44,7 @@ def model_params_from_ctx(
     return {
         key: value
         for key, value in ctx.params.items()
-        if key in model.__fields__ and value is not None
+        if key in model.__fields__ and (not filter_none or value is not None)
     }
 
 

--- a/harbor_cli/utils/args.py
+++ b/harbor_cli/utils/args.py
@@ -8,6 +8,8 @@ from typing import TypeVar
 import typer
 from pydantic import BaseModel
 
+from ..output.console import exit_err
+
 BaseModelType = TypeVar("BaseModelType", bound=BaseModel)
 
 
@@ -91,6 +93,8 @@ def create_updated_model(
         The updated model.
     """
     params = model_params_from_ctx(ctx, new)
+    if not params:
+        exit_err("No parameters provided to update")
     d = existing.dict()
     # Cast existing model to dict, update it with the new values
     d.update(params)

--- a/harbor_cli/utils/args.py
+++ b/harbor_cli/utils/args.py
@@ -51,6 +51,7 @@ def create_updated_model(
     new: Type[BaseModelType],
     ctx: typer.Context,
     extra: bool = False,
+    empty_ok: bool = False,
 ) -> BaseModelType:
     """Given a BaseModel and a new model type, create a new model
     from the fields of the existing model combined with the arguments given
@@ -91,8 +92,11 @@ def create_updated_model(
         The new model type to construct.
     ctx : typer.Context
         The Typer context to get the updated model parameters from.
-    extra : bool, optional
+    extra : bool
         Whether to include extra fields set on the existing model.
+    empty_ok: bool
+        Whether to allow the update to be empty. If False, an error will be raised
+        if no parameters are provided to update.
 
     Returns
     -------
@@ -100,7 +104,7 @@ def create_updated_model(
         The updated model.
     """
     params = model_params_from_ctx(ctx, new)
-    if not params:
+    if not params and not empty_ok:
         exit_err("No parameters provided to update")
 
     # Cast existing model to dict, update it with the new values

--- a/harbor_cli/utils/utils.py
+++ b/harbor_cli/utils/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions that can't be neatly categorized, or are so niche
+that they don't need their own module."""
 from __future__ import annotations
 
 import inspect
@@ -26,36 +28,6 @@ def replace_none(d: dict[str, Any], replacement: Any = "") -> dict[str, Any]:
         elif value is None:
             d[key] = replacement
     return d
-
-
-def parse_key_value_args(arg: list[str]) -> dict[str, str]:
-    """Parses a list of key=value arguments.
-
-    Examples
-    -------
-    >>> parse_key_value_args(["foo=bar", "baz=qux"])
-    {'foo': 'bar', 'baz': 'qux'}
-
-    Parameters
-    ----------
-    arg
-        A list of key=value arguments.
-
-    Returns
-    -------
-    dict[str, str]
-        A dictionary mapping keys to values.
-    """
-    metadata = {}
-    for item in arg:
-        try:
-            key, value = item.split("=", maxsplit=1)
-        except ValueError:
-            raise typer.BadParameter(
-                f"Invalid metadata item {item!r}. Expected format: key=value"
-            )
-        metadata[key] = value
-    return metadata
 
 
 def inject_help(


### PR DESCRIPTION
Originally, the `update` commands were designed to follow the API spec 1:1, but this has proven to be a cumbersome and unintuitive interface for users, and not at all a reflection of how the web interface does things. To improve the ergonomics of `update` commands, they now only take the fields the user wants to update, retrieves the current resource, updates the given fields, then submits the updated resource to the API.

Closes #7, as that is now deprecated in favor of this new approach.