### PR TITLE
Dynamic option help text from config override

### DIFF
--- a/docs/scripts/gen_cli_options.py
+++ b/docs/scripts/gen_cli_options.py
@@ -33,7 +33,7 @@ class OptInfo(NamedTuple):
     def to_dict(self) -> dict[str, str | None]:
         return {
             "params": ", ".join(f"`{p}`" for p in self.params),
-            "help": self.help,
+            "help": self.help or "",
             "envvar": maybe_list_to_str(self.envvar),
             "config_value": self.config_value,
             "fragment": self.fragment,

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -16,6 +16,9 @@ project list
 ## {{ option['params'] }}
 
 **Environment variable:** `{{ option['envvar'] }}`
+{% if option['config_value'] %}
+**Configuration value:** [`{{ option['config_value'] }}`](/configuration/config-file#{{option['fragment']}})
+{%- endif %}
 
 {{ option['help'] }}
 

--- a/harbor_cli/main.py
+++ b/harbor_cli/main.py
@@ -19,22 +19,23 @@ from .format import OutputFormat
 from .logs import disable_logging
 from .logs import logger
 from .logs import setup_logging
+from .option import Option
 from .output.console import exit_err
 from .output.console import success
 from .output.formatting.path import path_link
 from .state import state
-from .style import help_config_override
 
 # Init subcommand groups here
 for group in commands.ALL_GROUPS:
     app.add_typer(group)
+
 
 # The callback defines global command options
 @app.callback(no_args_is_help=True)
 def main_callback(
     ctx: typer.Context,
     # Configuration options
-    config_file: Optional[Path] = typer.Option(
+    config_file: Optional[Path] = Option(
         None,
         "--config",
         "-c",
@@ -42,109 +43,109 @@ def main_callback(
         envvar=env_var("config"),
     ),
     # Harbor options
-    harbor_url: Optional[str] = typer.Option(
+    harbor_url: Optional[str] = Option(
         None,
         "--url",
         "-u",
         Deprecated("--harbor-url", replacement="--url"),
-        help=f"Harbor API URL. {help_config_override('harbor.url')}",
+        help=f"Harbor API URL.",
         envvar=env_var("url"),
+        config_override="harbor.url",
     ),
-    harbor_username: Optional[str] = typer.Option(
+    harbor_username: Optional[str] = Option(
         None,
         "--username",
         "-U",
         Deprecated("--harbor-username", replacement="--username"),
-        help=f"Harbor username. {help_config_override('harbor.username')}",
+        help=f"Harbor username.",
         envvar=env_var("username"),
+        config_override="harbor.username",
     ),
-    harbor_secret: Optional[str] = typer.Option(
+    harbor_secret: Optional[str] = Option(
         None,
         "--secret",
         "-S",
         Deprecated("--harbor-secret", replacement="--secret"),
-        help=f"Harbor secret (password). {help_config_override('harbor.secret')}",
+        help=f"Harbor secret (password).",
         envvar=env_var("secret"),
+        config_override="harbor.secret",
     ),
-    harbor_basicauth: Optional[str] = typer.Option(
+    harbor_basicauth: Optional[str] = Option(
         None,
         "--basicauth",
         "-B",
-        help=f"Harbor basic access credentials (base64). {help_config_override('harbor.basicauth')}",
+        help=f"Harbor basic access credentials (base64).",
         envvar=env_var("basicauth"),
+        config_override="harbor.basicauth",
     ),
-    harbor_credentials_file: Optional[Path] = typer.Option(
+    harbor_credentials_file: Optional[Path] = Option(
         None,
         "--credentials-file",
         "-F",
-        help=f"Path to Harbor JSON credentials file. {help_config_override('harbor.credentials_file')}",
+        help=f"Path to Harbor JSON credentials file.",
         envvar=env_var("credentials_file"),
+        config_override="harbor.credentials_file",
     ),
     # Formatting
-    show_description: Optional[bool] = typer.Option(
+    show_description: Optional[bool] = Option(
         None,
         "--table-description/--no-table-description",
-        help=(
-            "Include field descriptions in tables. "
-            f"{help_config_override('output.table.description')}"
-        ),
+        help="Include field descriptions in tables.",
         envvar=env_var("table_description"),
+        config_override="output.table.description",
     ),
-    max_depth: Optional[int] = typer.Option(
+    max_depth: Optional[int] = Option(
         None,
         "--table-max-depth",
-        help=(
-            "Maximum depth to print nested objects in tables. "
-            f"{help_config_override('output.table.max_depth')}"
-        ),
+        help="Maximum depth to print nested objects in tables.",
         envvar=env_var("table_max_depth"),
+        config_override="output.table.max_depth",
     ),
-    compact: Optional[bool] = typer.Option(
+    compact: Optional[bool] = Option(
         None,
         "--table-compact/--no-table-compact",
-        help=(
-            "Compact table output. Has no effect on other formats. "
-            f"{help_config_override('output.table.compact')}"
-        ),
+        help="Compact table output. Has no effect on other formats. ",
         envvar=env_var("table_compact"),
+        config_override="output.table.compact",
     ),
-    json_indent: Optional[int] = typer.Option(
+    json_indent: Optional[int] = Option(
         None,
         "--json-indent",
-        help=f"Indentation level for JSON output. {help_config_override('output.json.indent')}",
+        help="Indentation level for JSON output.",
         envvar=env_var("json_indent"),
+        config_override="output.json.indent",
     ),
-    json_sort_keys: Optional[bool] = typer.Option(
+    json_sort_keys: Optional[bool] = Option(
         None,
         "--json-sort-keys/--no-json-sort-keys",
-        help=f"Sort keys in JSON output. {help_config_override('output.json.sort_keys')}",
+        help="Sort keys in JSON output.",
         envvar=env_var("json_sort_keys"),
+        config_override="output.json.sort_keys",
     ),
     # Output options
-    output_format: Optional[OutputFormat] = typer.Option(
+    output_format: Optional[OutputFormat] = Option(
         None,
         "--format",
         "-f",
-        help=f"Specifies the output format to use. {help_config_override('output.format')}",
+        help=f"Specifies the output format to use.",
         envvar=env_var("output_format"),
         case_sensitive=False,
+        config_override="output.format",
     ),
-    output_file: Optional[Path] = typer.Option(
+    output_file: Optional[Path] = Option(
         None,
         "--output",
         "-o",
         help="Output file, by default None, which means output to stdout. If the file already exists, it will be overwritten.",
     ),
-    no_overwrite: bool = typer.Option(
+    no_overwrite: bool = Option(
         False,
         "--no-overwrite",
         help="Do not overwrite the output file if it already exists.",
     ),
     # stdout/stderr options
-    verbose: bool = typer.Option(
-        False, "--verbose", "-v", help="Enable verbose output."
-    ),
-    with_stdout: bool = typer.Option(
+    verbose: bool = Option(False, "--verbose", "-v", help="Enable verbose output."),
+    with_stdout: bool = Option(
         False,
         "--with-stdout",
         help="Output to stdout in addition to the specified output file, if any. Has no effect if no output file is specified.",

--- a/harbor_cli/option.py
+++ b/harbor_cli/option.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+from typing import Optional
+
+import typer
+from typer.models import OptionInfo as _OptionInfo
+
+from .style import help_config_override
+
+
+class OptionInfo(_OptionInfo):
+    config_override: Optional[str] = None
+    _help_original: Optional[str] = None
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.config_override = kwargs.pop("config_override", None)
+        super().__init__(*args, **kwargs)
+
+        # Not sure why mypy can't infer the type of help
+        self.help = cast(Optional[str], self.help)  # type:ignore
+
+        # Backup the original help text
+        self._help_original = self.help
+        if self.config_override:
+            h = self.help or ""
+            if h and not h.endswith(" "):
+                h += " "
+            self.help = h + help_config_override(self.config_override)
+
+
+def Option(*args, **kwargs) -> Any:
+    kwargs.setdefault("show_envvar", False)  # disable by default
+    kwargs.setdefault("show_default", False)  # disable by default
+    config_override = kwargs.pop("config_override", None)
+
+    # I'm sure this won't break in the future :)
+    opt = typer.Option(*args, **kwargs)  # type: OptionInfo
+    return OptionInfo(
+        allow_dash=opt.allow_dash,
+        allow_from_autoenv=opt.allow_from_autoenv,
+        autocompletion=opt.autocompletion,
+        callback=opt.callback,
+        case_sensitive=opt.case_sensitive,
+        clamp=opt.clamp,
+        confirmation_prompt=opt.confirmation_prompt,
+        count=opt.count,
+        default=opt.default,
+        envvar=opt.envvar,
+        expose_value=opt.expose_value,
+        flag_value=opt.flag_value,
+        formats=opt.formats,
+        help=opt.help,
+        hidden=opt.hidden,
+        hide_input=opt.hide_input,
+        is_eager=opt.is_eager,
+        is_flag=opt.is_flag,
+        lazy=opt.lazy,
+        max=opt.max,
+        metavar=opt.metavar,
+        min=opt.min,
+        mode=opt.mode,
+        param_decls=opt.param_decls,
+        prompt=opt.prompt,
+        prompt_required=opt.prompt_required,
+        shell_complete=opt.shell_complete,
+        show_choices=opt.show_choices,
+        show_default=opt.show_default,
+        show_envvar=opt.show_envvar,
+        config_override=config_override,
+    )

--- a/harbor_cli/option.py
+++ b/harbor_cli/option.py
@@ -30,10 +30,9 @@ class OptionInfo(_OptionInfo):
             self.help = h + help_config_override(self.config_override)
 
 
-def Option(*args, **kwargs) -> Any:
+def Option(*args, config_override: str | None = None, **kwargs: Any) -> Any:
     kwargs.setdefault("show_envvar", False)  # disable by default
     kwargs.setdefault("show_default", False)  # disable by default
-    config_override = kwargs.pop("config_override", None)
 
     # I'm sure this won't break in the future :)
     opt = typer.Option(*args, **kwargs)  # type: OptionInfo

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from harbor_cli.config import env_var
+from harbor_cli.option import Option
+from harbor_cli.style import help_config_override
+
+
+def test_option() -> None:
+    base_help = "Base help text."
+    default = "default"
+    info = Option(
+        default,
+        "--option",
+        "-o",
+        help=base_help,
+        envvar=env_var("OPTION"),
+        config_override="option",
+    )
+
+    # The help text should be updated with the config override info
+    assert info.help == base_help + " " + help_config_override("option")
+    assert info._help_original == base_help
+    assert info.config_override == "option"
+    # Test the rest of the attributes
+    assert info.envvar == env_var("OPTION")
+    assert info.param_decls == ("--option", "-o")
+    assert info.default == default
+
+
+def test_option_no_config_override() -> None:
+    info = Option("default", "--option", "-o", help="Help text.")
+
+    # The help text should be updated with the config override info
+    assert info.help == "Help text."
+    assert info._help_original == info.help
+    # Test the rest of the attributes
+    assert info.param_decls == ("--option", "-o")
+    assert info.default == "default"
+
+
+def test_option_no_help() -> None:
+    info = Option("default", "--option", "-o")
+
+    # The help text should be updated with the config override info
+    assert info.help is None
+    assert info._help_original is None
+    # Test the rest of the attributes
+    assert info.param_decls == ("--option", "-o")
+    assert info.default == "default"


### PR DESCRIPTION
This pull request resolves #36 by adding a new `harbor_cli.option.Option` function. We use this to render the config value it overrides in the help text of the command, as well as on the "Options" page in the docs.