### PR TITLE
Add configurable table styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The **third number** is the patch version (bug fixes)
 - Option: `user list --sort [id|username|name]`.
 - `UserResp` compact table format (used by `user list`).
 - `--paging`, `--pager` options and corresponding config options for displaying results in a pager.
+- `[output.table.style]` config section for styling Rich tables.
 
 ### Changed
 

--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -199,7 +199,7 @@ Style of table titles.
 
 ```toml
 [output.table.style]
-title = "bold green
+title = "bold green"
 ```
 
 #### `output.table.style.header`
@@ -208,7 +208,7 @@ Style of table headers.
 
 ```toml
 [output.table.style]
-header = "bold green
+header = "bold green"
 ```
 
 #### `output.table.style.rows`
@@ -235,7 +235,7 @@ Styling of border characters.
 
 ```toml
 [output.table.style]
-border = "bold green
+border = "bold green"
 ```
 
 #### `output.table.style.footer`
@@ -244,7 +244,7 @@ Styling of table footers.
 
 ```toml
 [output.table.style]
-footer = "bold green
+footer = "bold green"
 ```
 
 #### `output.table.style.caption`
@@ -253,5 +253,5 @@ Styling of table captions.
 
 ```toml
 [output.table.style]
-caption = "bold green
+caption = "bold green"
 ```

--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -186,3 +186,72 @@ compact = false
 ```
 
 See [Formats: Compact Table](/configuration/formats/#compact-tables) for more information.
+
+
+### `output.table.style`
+
+Configuration for styling of Rich tables. Largely follows style options of [Rich tables](https://rich.readthedocs.io/en/stable/tables.html#table-options). Styles are specified as [Rich styles](https://rich.readthedocs.io/en/stable/style.html#styles).
+
+
+#### `output.table.style.title`
+
+Style of table titles.
+
+```toml
+[output.table.style]
+title = "bold green
+```
+
+#### `output.table.style.header`
+
+Style of table headers.
+
+```toml
+[output.table.style]
+header = "bold green
+```
+
+#### `output.table.style.rows`
+
+Style of table rows. Can be a list of two different styles, one for even rows and one for odd rows, or a string specifying a single style for all rows.
+
+To style alternating rows only, provide a list where one of the elements is an empty string. First element for odd rows, second element for even rows.
+
+
+```toml
+[output.table.style]
+rows = "black on white"
+# or (same as above)
+rows = ["black on white", "white on black"]
+# or (odd rows only)
+rows = ["black on white", ""]
+# or (even rows only)
+rows = ["", "black on white"]
+```
+
+#### `output.table.style.border`
+
+Styling of border characters.
+
+```toml
+[output.table.style]
+border = "bold green
+```
+
+#### `output.table.style.footer`
+
+Styling of table footers.
+
+```toml
+[output.table.style]
+footer = "bold green
+```
+
+#### `output.table.style.caption`
+
+Styling of table captions.
+
+```toml
+[output.table.style]
+caption = "bold green
+```

--- a/harbor_cli/output/table/_utils.py
+++ b/harbor_cli/output/table/_utils.py
@@ -8,6 +8,7 @@ from rich.console import RenderableType
 from rich.panel import Panel
 from rich.table import Table
 
+from ...state import state
 from ..formatting.builtin import plural_str
 
 
@@ -28,7 +29,10 @@ def get_table(
     # Set kwargs defaults (so we don't accidentally pass them twice)
     kwargs.setdefault("show_header", True)
     kwargs.setdefault("expand", True)
-    kwargs.setdefault("header_style", "bold magenta")
+    styleconf = state.config.output.table.style
+    style_kwargs = styleconf.as_rich_kwargs()
+    for k, v in style_kwargs.items():
+        kwargs.setdefault(k, v)
 
     table = Table(
         title=title,
@@ -45,5 +49,5 @@ def get_panel(
     title: str | None = None,
     expand: bool = True,
 ) -> Panel:
-    """Get a panel with a title."""
+    """Get a panel from a sequence of renderables."""
     return Panel(Group(*renderables), title=title, expand=expand)

--- a/harbor_cli/style.py
+++ b/harbor_cli/style.py
@@ -7,6 +7,8 @@ STYLE_CONFIG_OPTION = "italic yellow"
 STYLE_CLI_OPTION = "green"
 """The style used to signify a CLI option, e.g. --verbose."""
 
+STYLE_TABLE_HEADER = "bold green"
+
 
 def render_config_option(option: str) -> str:
     """Render a configuration file option/key/entry."""


### PR DESCRIPTION
This pull request adds the ability to add custom styles for tables. For now, it only affects compact tables, but in the future, this should be able to affect `harborapi` built-in tables as well.

The styling is done via a new `[output.table.style]` section in the config file.

Closes #30 