### PR TITLE
Dynamically build list of compact table functions, pass kwargs

### DIFF
--- a/harbor_cli/models.py
+++ b/harbor_cli/models.py
@@ -7,7 +7,12 @@ Refactor to module (directory with __init__.py) if needed.
 from __future__ import annotations
 
 from harborapi.models import Project
-from harborapi.models.base import BaseModel
+from harborapi.models.base import BaseModel as HarborAPIBaseModel
+
+
+class BaseModel(HarborAPIBaseModel):
+    pass
+
 
 # TODO: split up CommandSummary into CommandSummary and CommandSearchResult
 # so that the latter can have the score field

--- a/harbor_cli/output/table/__init__.py
+++ b/harbor_cli/output/table/__init__.py
@@ -132,7 +132,7 @@ def get_render_function(
     else:
         t = type(obj)
 
-    def _get_render_func(t: Type[T]) -> RENDER_FUNC_T:
+    def _get_render_func(t: Any) -> RENDER_FUNC_T:
         try:
             return RENDER_FUNCTIONS[t]
         except KeyError:
@@ -143,15 +143,18 @@ def get_render_function(
                 )
             raise NotImplementedError(f"{t} not implemented.")
 
+    # try to get the single obj render func
     try:
         return _get_render_func(t)
+    # fall back on the sequence render func
     except NotImplementedError:
-        return _get_render_func(Sequence[t])  # type: ignore
+        return _get_render_func(Sequence[t])  # type: ignore # variable as type (mypy hates it)
 
 
 def get_renderable(obj: T | Sequence[T], **kwargs: Any) -> Table | Panel:
     """Get the renderable for a given object."""
     render_function = get_render_function(obj)
+    # wrap object in sequence if necessary (use sequence func if we cant find a single func)
     if is_sequence_func(render_function) and not isinstance(obj, Sequence):
         return render_function([obj], **kwargs)
     return render_function(obj, **kwargs)  # type: ignore

--- a/harbor_cli/output/table/__init__.py
+++ b/harbor_cli/output/table/__init__.py
@@ -16,10 +16,15 @@ a rich.table.Table object.
 """
 from __future__ import annotations
 
+import typing
+from collections import abc
 from typing import Any
 from typing import Callable
+from typing import List
 from typing import Sequence
+from typing import Type
 from typing import TypeVar
+from typing import Union
 
 from harborapi.ext.artifact import ArtifactInfo
 from harborapi.models import Artifact
@@ -31,15 +36,20 @@ from harborapi.models import Search
 from harborapi.models import SystemInfo
 from harborapi.models import UserResp
 from harborapi.models import UserSearchRespItem
+from harborapi.models.scanner import HarborVulnerabilityReport
 from rich.panel import Panel
 from rich.table import Table
 
+from ...logs import logger
+from ...models import BaseModel
 from ...models import CommandSummary
 from ...models import ProjectExtended
 from ...utils._types import is_builtin_obj
 from .anysequence import AnySequence
 from .anysequence import anysequence_table
 from .artifact import artifact_table
+from .artifact import artifact_vulnerabilities_table
+from .artifact import artifactinfo_panel
 from .artifact import artifactinfo_table
 from .auditlog import auditlog_table
 from .commandsummary import commandsummary_table
@@ -54,23 +64,57 @@ from .user import usersearchrespitem_table
 
 T = TypeVar("T")
 
+_RENDER_FUNC_SEQ = Callable[[Sequence[T]], Union[Table, Panel]]
+_RENDER_FUNC_SINGLE = Callable[[T], Union[Table, Panel]]
+RENDER_FUNC_T = Union[_RENDER_FUNC_SEQ, _RENDER_FUNC_SINGLE]
 
-RENDER_FUNCTIONS = {
-    AnySequence: anysequence_table,
-    ArtifactInfo: artifactinfo_table,
-    Artifact: artifact_table,
-    AuditLog: auditlog_table,
-    CommandSummary: commandsummary_table,
-    Project: project_table,
-    ProjectExtended: project_extended_panel,
-    Repository: repository_table,
-    SystemInfo: systeminfo_table,
-    Search: search_panel,
-    UserResp: userresp_table,
-    UserSearchRespItem: usersearchrespitem_table,
-    RegistryProviders: registryproviders_table,
-}  # type: dict[type, Callable[[Any], Table | Panel]]
-# TODO: improve type annotation of this dict
+
+_RENDER_FUNCTIONS = [
+    anysequence_table,
+    artifactinfo_table,
+    artifactinfo_panel,
+    artifact_table,
+    auditlog_table,
+    commandsummary_table,
+    artifact_vulnerabilities_table,
+    project_table,
+    project_extended_panel,
+    repository_table,
+    systeminfo_table,
+    search_panel,
+    userresp_table,
+    usersearchrespitem_table,
+    registryproviders_table,
+]  # type: list[RENDER_FUNC_T]
+
+RENDER_FUNCTIONS = {}  # dict of functions + type of first argument
+for function in _RENDER_FUNCTIONS:
+    hints = typing.get_type_hints(function)
+    if not hints:
+        continue
+    val = next(iter(hints.values()))
+    try:
+        RENDER_FUNCTIONS[val] = function
+    except TypeError:
+        logger.warning("Could not add render function %s", function)
+
+# RENDER_FUNCTIONS = {
+#     AnySequence: anysequence_table,
+#     ArtifactInfo: artifactinfo_table,
+#     Artifact: artifact_table,
+#     AuditLog: auditlog_table,
+#     CommandSummary: commandsummary_table,
+#     HarborVulnerabilityReport: artifact_vulnerabilities_table,
+#     Project: project_table,
+#     ProjectExtended: project_extended_panel,
+#     Repository: repository_table,
+#     SystemInfo: systeminfo_table,
+#     Search: search_panel,
+#     UserResp: userresp_table,
+#     UserSearchRespItem: usersearchrespitem_table,
+#     RegistryProviders: registryproviders_table,
+# }  # type: dict[type, Callable[[Any], Table | Panel]]
+# # TODO: improve type annotation of this dict
 
 
 class BuiltinTypeException(TypeError):
@@ -81,28 +125,46 @@ class EmptySequenceError(ValueError):
     pass
 
 
+def is_sequence_func(func: Callable[[Any], Any]) -> bool:
+    hints = typing.get_type_hints(func)
+    if not hints:
+        return False
+    val = next(iter(hints.values()))
+    origin = typing.get_origin(val)
+    return origin in [Sequence, abc.Sequence, list, List]
+
+
 def get_render_function(
     obj: T | Sequence[T],
-) -> Callable[[Sequence[T]], Table | Panel]:
+) -> RENDER_FUNC_T:
     """Get the render function for a given object."""
 
     if isinstance(obj, Sequence):
-        if not obj:
+        if len(obj) == 0:
             raise EmptySequenceError("Cannot render empty sequence.")
-        obj = obj[0]
+        t = Sequence[type(obj[0])]  # type: ignore # TODO: fix this
+    else:
+        t = type(obj)
+
+    def _get_render_func(t: Type[T]) -> RENDER_FUNC_T:
+        try:
+            return RENDER_FUNCTIONS[t]
+        except KeyError:
+            if is_builtin_obj(t):
+                raise BuiltinTypeException(
+                    "Builtin types cannot be rendered as a compact table."
+                )
+            raise NotImplementedError(f"{type(obj)} not implemented.")
+
     try:
-        return RENDER_FUNCTIONS[obj.__class__]
-    except KeyError:
-        if is_builtin_obj(obj):
-            raise BuiltinTypeException(
-                "Builtin types cannot be rendered as a compact table."
-            )
-        raise NotImplementedError(f"{type(obj)} not implemented.")
+        return _get_render_func(t)
+    except NotImplementedError:
+        return _get_render_func(Sequence[t])  # type: ignore
 
 
-def get_renderable(obj: T | Sequence[T]) -> Table | Panel:
+def get_renderable(obj: T | Sequence[T], **kwargs: Any) -> Table | Panel:
     """Get the renderable for a given object."""
     render_function = get_render_function(obj)
-    if not isinstance(obj, Sequence):
-        obj = [obj]
-    return render_function(obj)
+    if is_sequence_func(render_function) and not isinstance(obj, Sequence):
+        return render_function([obj], **kwargs)
+    return render_function(obj, **kwargs)  # type: ignore

--- a/harbor_cli/output/table/anysequence.py
+++ b/harbor_cli/output/table/anysequence.py
@@ -19,7 +19,7 @@ class AnySequence(BaseModel):
     values: Sequence[Any] = []
 
 
-def anysequence_table(s: Sequence[AnySequence]) -> Table:
+def anysequence_table(s: Sequence[AnySequence], **kwargs: Any) -> Table:
     """Renders an AnySequence as a table."""
     # No title here I think...?
     table = get_table()

--- a/harbor_cli/output/table/artifact.py
+++ b/harbor_cli/output/table/artifact.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from harborapi.ext.artifact import ArtifactInfo
 from harborapi.models.models import Artifact
+from harborapi.models.scanner import HarborVulnerabilityReport
 from rich.table import Table
 
 from ..formatting.builtin import float_str
@@ -11,11 +13,12 @@ from ..formatting.builtin import int_str
 from ..formatting.builtin import str_str
 from ..formatting.bytes import bytesize_str
 from ..formatting.dates import datetime_str
+from ._utils import get_panel
 from ._utils import get_table
 
 
-def artifact_table(artifacts: Sequence[Artifact]) -> Table:
-    """Display one or more repositories in a table."""
+def artifact_table(artifacts: Sequence[Artifact], **kwargs: Any) -> Table:
+    """Display one or more artifacts in a table."""
     table = get_table("Artifact", artifacts)
     table.add_column("ID")
     table.add_column("Project ID")
@@ -41,9 +44,9 @@ def artifact_table(artifacts: Sequence[Artifact]) -> Table:
     return table
 
 
-def artifactinfo_table(artifacts: Sequence[ArtifactInfo]):
+def artifactinfo_table(artifacts: Sequence[ArtifactInfo], **kwargs: Any):
     """Display one or more artifacts (ArtifactInfo) in a table."""
-    table = table = get_table("Artifact", artifacts)
+    table = get_table("Artifact", artifacts)
     table.add_column("Project")
     table.add_column("Repository")
     table.add_column("Tags")
@@ -75,24 +78,57 @@ def artifactinfo_table(artifacts: Sequence[ArtifactInfo]):
     return table
 
 
-def artifact_vulnerabilities_table(artifact: ArtifactInfo):
-    vulns = artifact.report.vulnerabilities
-    table = table = get_table("Vulnerability", vulns, show_lines=True)
+def artifactinfo_panel(artifact: ArtifactInfo, **kwargs: Any):
+    """Display one or more artifacts (ArtifactInfo) in a table."""
+
+    artifact_table = artifactinfo_table([artifact], **kwargs)
+    vuln_table = artifact_vulnerabilities_table([artifact.report], **kwargs)
+    panel = get_panel([artifact_table, vuln_table], title=artifact.name_with_digest)
+    return panel
+
+
+def artifact_vulnerabilities_table(
+    reports: Sequence[HarborVulnerabilityReport], **kwargs: Any
+):
+    table = get_table("Vulnerabilities", show_lines=True)
     table.add_column("CVE ID")
     table.add_column("Severity")
     table.add_column("Score")
     table.add_column("Package")
     table.add_column("Version", overflow="fold")
     table.add_column("Fix Version", overflow="fold")
-    table.add_column("Description")
-    for vulnerability in vulns:
-        table.add_row(
-            str_str(vulnerability.id),
-            str_str(vulnerability.severity.value),
-            float_str(vulnerability.get_cvss_score()),
-            str_str(vulnerability.package),
-            str_str(vulnerability.version),
-            str_str(vulnerability.fix_version),
-            str_str(vulnerability.description),
-        )
-    return table
+    with_desc = kwargs.get("with_description", False)
+    if with_desc:
+        table.add_column("Description")
+
+    # TODO: add vulnerability sorting
+    for report in reports:
+        vulns = report.vulnerabilities
+        for vulnerability in vulns:
+            row = [
+                str_str(vulnerability.id),
+                str_str(vulnerability.severity.value),
+                float_str(vulnerability.get_cvss_score()),
+                str_str(vulnerability.package),
+                str_str(vulnerability.version),
+                str_str(vulnerability.fix_version),
+            ]
+            if with_desc:
+                row.append(str_str(vulnerability.description))
+            table.add_row(*row)
+        return table
+
+
+# def scheduled_artifact_deletion_table(
+#     artifacts: Sequence["ScheduledArtifactDeletion"],
+# ) -> Table:
+#     """Display one or more artifacts in a table."""
+#     table = get_table("Scheduled Artifact Deletion", artifacts)
+#     table.add_column("Artifact")
+#     table.add_column("Reasons")
+#     for artifact in artifacts:
+#         table.add_row(
+#             str_str(artifact.artifact),
+#             str_str(",".join([r for r in artifact.reasons])),
+#         )
+#     return table

--- a/harbor_cli/output/table/auditlog.py
+++ b/harbor_cli/output/table/auditlog.py
@@ -3,6 +3,7 @@
 # vertical arrangement of the auto generated output.
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from harborapi.models.models import AuditLog
@@ -14,7 +15,7 @@ from ..formatting.dates import datetime_str
 from ._utils import get_table
 
 
-def auditlog_table(logs: Sequence[AuditLog]) -> Table:
+def auditlog_table(logs: Sequence[AuditLog], **kwargs: Any) -> Table:
     table = get_table(
         "Audit Log",
         logs,

--- a/harbor_cli/output/table/commandsummary.py
+++ b/harbor_cli/output/table/commandsummary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from rich.table import Table
@@ -9,12 +10,9 @@ from ..formatting.builtin import int_str
 from ._utils import get_table
 
 
-def commandsummary_table(c: Sequence[CommandSummary]) -> Table:
+def commandsummary_table(c: Sequence[CommandSummary], **kwargs: Any) -> Table:
     """Display summary of commands in a table."""
-    table = get_table("Results", c)
-    table.add_column("Command")
-    table.add_column("Description")
-
+    table = get_table("Results", c, columns=["Command", "Description"])
     # If we got these commands from a search, we can show a score
     has_score = any(cmd.score for cmd in c)
     if has_score:

--- a/harbor_cli/output/table/project.py
+++ b/harbor_cli/output/table/project.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from harborapi.models.models import CVEAllowlist
@@ -17,7 +18,7 @@ from ..formatting.dates import datetime_str
 from ._utils import get_table
 
 
-def project_table(p: Sequence[Project]) -> Table:
+def project_table(p: Sequence[Project], **kwargs: Any) -> Table:
     """Display one or more projects in a table."""
     table = get_table("Project", p)
     table.add_column("ID")
@@ -36,7 +37,7 @@ def project_table(p: Sequence[Project]) -> Table:
     return table
 
 
-def project_extended_panel(p: Sequence[ProjectExtended]) -> Panel:
+def project_extended_panel(p: Sequence[ProjectExtended], **kwargs: Any) -> Panel:
     """Display extended information about one or more projects."""
     if len(p) > 1:
         logger.warning("This function should only be used to display a single project.")
@@ -47,7 +48,7 @@ def project_extended_panel(p: Sequence[ProjectExtended]) -> Panel:
     return Panel(Group(pt_table, pmt_table, cve_table), title=p[0].name, expand=True)
 
 
-def project_extended_table(p: Sequence[ProjectExtended]) -> Table:
+def project_extended_table(p: Sequence[ProjectExtended], **kwargs: Any) -> Table:
     table = get_table(
         "Project",
         p,
@@ -74,7 +75,7 @@ def project_extended_table(p: Sequence[ProjectExtended]) -> Table:
     return table
 
 
-def project_metadata_table(p: Sequence[ProjectMetadata]) -> Table:
+def project_metadata_table(p: Sequence[ProjectMetadata], **kwargs: Any) -> Table:
     table = get_table("Project Metadata", p)
     table.add_column("Public")
     table.add_column("Content Trust")
@@ -98,7 +99,7 @@ def project_metadata_table(p: Sequence[ProjectMetadata]) -> Table:
     return table
 
 
-def cveallowlist_table(c: Sequence[CVEAllowlist]) -> Table:
+def cveallowlist_table(c: Sequence[CVEAllowlist], **kwargs: Any) -> Table:
     table = get_table("CVE Allowlist", c)
     table.add_column("ID")
     table.add_column("Items")

--- a/harbor_cli/output/table/registry.py
+++ b/harbor_cli/output/table/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from harborapi.models.models import RegistryProviderInfo
@@ -12,7 +13,7 @@ from ._utils import get_table
 
 
 def registryproviders_table(
-    providers: Sequence[RegistryProviders],
+    providers: Sequence[RegistryProviders], **kwargs: Any
 ) -> Table:
     """Renders a list of RegistryProvider objects as individual tables in a panel."""
     if len(providers) > 1:
@@ -24,7 +25,7 @@ def registryproviders_table(
     return table
 
 
-def _registryproviderinfo_table(provider: RegistryProviderInfo) -> Table:
+def _registryproviderinfo_table(provider: RegistryProviderInfo, **kwargs: Any) -> Table:
     table = get_table(
         columns=[
             "Endpoint",

--- a/harbor_cli/output/table/repository.py
+++ b/harbor_cli/output/table/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from harborapi.models.models import Repository
@@ -9,7 +10,7 @@ from ..formatting.dates import datetime_str
 from ._utils import get_table
 
 
-def repository_table(r: Sequence[Repository]) -> Table:
+def repository_table(r: Sequence[Repository], **kwargs: Any) -> Table:
     """Display one or more repositories in a table."""
     table = get_table(
         "Repository",

--- a/harbor_cli/output/table/search.py
+++ b/harbor_cli/output/table/search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from harborapi.models.models import ChartVersion
@@ -18,7 +19,7 @@ from ._utils import get_table
 from .project import project_table
 
 
-def search_panel(search: Sequence[Search]) -> Panel:
+def search_panel(search: Sequence[Search], **kwargs: Any) -> Panel:
     """Display one or more repositories in a table."""
     if len(search) > 1:
         logger.warning("Can only display one search result at a time.")
@@ -40,7 +41,7 @@ def search_panel(search: Sequence[Search]) -> Panel:
     return Panel(Group(*tables), title=f"Search Results", expand=True)
 
 
-def searchrepo_table(repos: Sequence[SearchRepository]) -> Table:
+def searchrepo_table(repos: Sequence[SearchRepository], **kwargs: Any) -> Table:
     table = get_table("Repository", repos)
     table.add_column("Project")
     table.add_column("Name")
@@ -56,7 +57,7 @@ def searchrepo_table(repos: Sequence[SearchRepository]) -> Table:
     return table
 
 
-def searchresult_table(results: Sequence[SearchResult]) -> Table:
+def searchresult_table(results: Sequence[SearchResult], **kwargs: Any) -> Table:
     """Table of Helm chart search results."""
     table = get_table("Chart", results)
     table.add_column("Project")

--- a/harbor_cli/output/table/system.py
+++ b/harbor_cli/output/table/system.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from harborapi.models.models import Storage
@@ -13,7 +14,7 @@ from ._utils import get_table
 
 # The ironic thing is that this is not actually system info, but storage info.
 # GeneralInfo is the model used for general system info.
-def systeminfo_table(systeminfo: Sequence[SystemInfo]) -> Table:
+def systeminfo_table(systeminfo: Sequence[SystemInfo], **kwargs: Any) -> Table:
     """Display system info in a table."""
     if len(systeminfo) > 1:
         # should never happen

--- a/harbor_cli/output/table/user.py
+++ b/harbor_cli/output/table/user.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Sequence
 
 from harborapi.models.models import UserResp
@@ -9,7 +10,7 @@ from rich.table import Table
 from ._utils import get_table
 
 
-def userresp_table(users: Sequence[UserResp]) -> Table:
+def userresp_table(users: Sequence[UserResp], **kwargs: Any) -> Table:
     """Display one or more users in a table."""
     table = get_table(
         "User",
@@ -25,7 +26,9 @@ def userresp_table(users: Sequence[UserResp]) -> Table:
     return table
 
 
-def usersearchrespitem_table(users: Sequence[UserSearchRespItem]) -> Table:
+def usersearchrespitem_table(
+    users: Sequence[UserSearchRespItem], **kwargs: Any
+) -> Table:
     """Display one or more users found in a user search."""
     table = get_table("Results", columns=["ID", "Username"])
 

--- a/tests/_strategies.py
+++ b/tests/_strategies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from typing import TYPE_CHECKING
 
 from hypothesis import strategies as st
@@ -11,6 +12,11 @@ if TYPE_CHECKING:
 from harbor_cli.output.table import RENDER_FUNCTIONS
 
 
-COMPACT_TABLE_MODELS = st.one_of(
-    [st.builds(model) for model in RENDER_FUNCTIONS.keys()]
-)  # type: SearchStrategy[BaseModel]
+COMPACT_TABLE_MODELS = []  # type: list[SearchStrategy[BaseModel | list[BaseModel]]]
+for model in RENDER_FUNCTIONS.keys():
+    try:
+        args = typing.get_args(model)
+        strategy = st.lists(st.builds((args[0])), min_size=1)
+    except (TypeError, IndexError):
+        strategy = st.builds(model)
+    COMPACT_TABLE_MODELS.append(strategy)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from typing import NamedTuple
 from typing import Optional
 
@@ -26,4 +27,12 @@ for model in RENDER_FUNCTIONS.keys():
         obj = model()
     except ValidationError:
         continue
+    except TypeError:
+        try:
+            # hints = typing.get_type_hints(model)
+            # val = next(iter(hints.values()))
+            args = typing.get_args(model)
+            args[0]()
+        except ValidationError:
+            continue
     compact_renderables.append(model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,8 @@ from harbor_cli.main import app as main_app  # noreorder
 from harbor_cli.config import HarborCLIConfig
 from harbor_cli.format import OutputFormat
 from harbor_cli import state
-from ._utils import compact_renderables
 
+from ._strategies import COMPACT_TABLE_MODELS
 
 runner = CliRunner()
 
@@ -114,14 +114,16 @@ def revert_state() -> Generator[None, None, None]:
     state.state = _ORIGINAL_STATE
 
 
-@pytest.fixture(scope="function", params=compact_renderables)
-def compact_table_renderable(request: pytest.FixtureRequest) -> BaseModel:
-    """Fixture for testing compact table renderables that can be instantiated with no arguments."""
-    return request.param()
-
-
 @pytest.fixture
 def caplog(caplog: LogCaptureFixture):
     handler_id = logger.add(caplog.handler, format="{message}")
     yield caplog
     logger.remove(handler_id)
+
+
+@pytest.fixture(scope="function", params=COMPACT_TABLE_MODELS)
+def compact_table_renderable(request: pytest.FixtureRequest) -> BaseModel:
+    """Fixture for testing compact table renderables that can be instantiated with no arguments."""
+    # NOTE: kind of janky, but it lets us generate examples for functions that use
+    # pytest-mock's mocker fixture, which doesn't work when using hypothesis it seems?
+    return request.param.example()

--- a/tests/output/test_render.py
+++ b/tests/output/test_render.py
@@ -103,10 +103,12 @@ def test_render_table_compact_fallback(mocker: MockerFixture) -> None:
 
 
 # TODO: fix not being able to combine mocker and hypothesis
+
+
 def test_render_table_full_mock(
     mocker: MockerFixture, compact_table_renderable: BaseModel
 ) -> None:
-    """Test that we can render a result as a compact table."""
+    """Test that we can render a result as a full table."""
     # FIXME: getting the following error when attempting to create mock
     # for render_table and render_table_compact:
     # TypeError: __name__ must be set to a string object


### PR DESCRIPTION
This pull request makes all render functions take an arbitrary number of kwargs, allowing for callers to control certain behavior related to these functions.

Furthermore, the list of compact table functions is now constructed based on the type annotation of the first argument each render function takes, ensuring that the mapping always points to the correct compact table function for each type. Together with this change, compact table functions do not have to _always_ take sequences anymore, and can instead choose to take sequences or single `BaseModel` objects depending on what's appropriate. Non-sequence objects attempt to re-use sequence compact table functions when they don't have their own compact table function, similar to to how they used to behave.


## On Complexity

This pull request adds a great deal of complexity to `harbor_cli.output.table.__init__`, which is not ideal, but I can't think of a better way to achieve this right now. The existing way of wrapping models in lists and having each compact table function only take sequences, lead to a LOT of jank. A lot of models simply weren't designed to be aggregated, and it's extremely awkward to have to warn if a sequence contains more than one element.

So while having a hand-written mapping of types to compact table function, and _only_ taking sequences was simple, it just wasn't very practical in terms of writing and re-using the various compact table functions. The new system makes it so we can write different compact table functions based on whether or not we are dealing with a single model or an aggregate of models (list of models). This way, we can write more extensive compact table functions for the single instances, while the aggregates contain more of a summary.