### PR TITLE
Change ID arg semantics

### DIFF
--- a/harbor_cli/commands/api/webhook.py
+++ b/harbor_cli/commands/api/webhook.py
@@ -7,9 +7,8 @@ import typer
 from ...output.render import render_result
 from ...state import state
 from ...utils.args import get_project_arg
-from ...utils.commands import ARG_PROJECT_NAME
+from ...utils.commands import ARG_PROJECT_NAME_OR_ID
 from ...utils.commands import inject_resource_options
-from ...utils.commands import OPTION_PROJECT_ID
 from ...utils.prompts import check_enumeration_options
 
 # Create a command group
@@ -24,12 +23,11 @@ app.add_typer(policy_cmd)
 @inject_resource_options()
 async def get_webhook_jobs(
     ctx: typer.Context,
-    project_name: Optional[str] = ARG_PROJECT_NAME,
+    project_name_or_id: str = ARG_PROJECT_NAME_OR_ID,
     policy_id: int = typer.Option(
         ...,
         help="ID of the webhook policy to list jobs for.",
     ),
-    project_id: Optional[int] = OPTION_PROJECT_ID,
     query: Optional[str] = ...,  # type: ignore
     sort: Optional[str] = ...,  # type: ignore
     page: int = ...,  # type: ignore
@@ -38,7 +36,7 @@ async def get_webhook_jobs(
 ) -> None:
     """Get project webhook jobs for a given policy."""
     check_enumeration_options(state, query=query, limit=limit)
-    project_arg = get_project_arg(project_name, project_id)
+    project_arg = get_project_arg(project_name_or_id)
     result = state.run(
         state.client.get_webhook_jobs(
             project_arg,
@@ -57,11 +55,10 @@ async def get_webhook_jobs(
 @app.command("triggers")
 def get_webhook_policy_last_trigger(
     ctx: typer.Context,
-    project_name: Optional[str] = ARG_PROJECT_NAME,
-    project_id: Optional[int] = OPTION_PROJECT_ID,
+    project_name_or_id: str = ARG_PROJECT_NAME_OR_ID,
 ) -> None:
     """Get the last triggers for a webhook policy."""
-    project_arg = get_project_arg(project_name, project_id)
+    project_arg = get_project_arg(project_name_or_id)
     result = state.run(state.client.get_webhook_policy_last_trigger(project_arg))
     render_result(result, ctx)
 
@@ -70,11 +67,10 @@ def get_webhook_policy_last_trigger(
 @app.command("events", no_args_is_help=True)
 def get_webhook_policy_(
     ctx: typer.Context,
-    project_name: Optional[str] = ARG_PROJECT_NAME,
-    project_id: Optional[int] = OPTION_PROJECT_ID,
+    project_name_or_id: str = ARG_PROJECT_NAME_OR_ID,
 ) -> None:
     """Get the supported webhook event types."""
-    project_arg = get_project_arg(project_name, project_id)
+    project_arg = get_project_arg(project_name_or_id)
     result = state.run(state.client.get_webhook_supported_events(project_arg))
     render_result(result, ctx)
 
@@ -84,8 +80,7 @@ def get_webhook_policy_(
 @inject_resource_options()
 def get_webhook_policies(
     ctx: typer.Context,
-    project_name: Optional[str] = ARG_PROJECT_NAME,
-    project_id: Optional[int] = OPTION_PROJECT_ID,
+    project_name_or_id: str = ARG_PROJECT_NAME_OR_ID,
     query: Optional[str] = ...,  # type: ignore
     sort: Optional[str] = ...,  # type: ignore
     page: int = ...,  # type: ignore
@@ -94,7 +89,7 @@ def get_webhook_policies(
 ) -> None:
     """List webhook policies."""
     check_enumeration_options(state, query=query, limit=limit)
-    project_arg = get_project_arg(project_name, project_id)
+    project_arg = get_project_arg(project_name_or_id)
     result = state.run(
         state.client.get_webhook_policies(
             project_arg,
@@ -112,12 +107,11 @@ def get_webhook_policies(
 @policy_cmd.command("get")
 def get_webhook_policy(
     ctx: typer.Context,
-    project_name: Optional[str] = ARG_PROJECT_NAME,
+    project_name_or_id: str = ARG_PROJECT_NAME_OR_ID,
     policy_id: int = typer.Option(..., help="ID of the webhook policy to get."),
-    project_id: Optional[int] = OPTION_PROJECT_ID,
 ) -> None:
     """Get a webhook policy."""
-    project_arg = get_project_arg(project_name, project_id)
+    project_arg = get_project_arg(project_name_or_id)
     result = state.run(state.client.get_webhook_policy(project_arg, policy_id))
     render_result(result, ctx)
 
@@ -128,7 +122,7 @@ def get_webhook_policy(
 # @inject_help(WebhookPolicy)
 # def create_webhook_policy(
 #     ctx: typer.Context,
-#     project_name: Optional[str] = ARG_PROJECT_NAME,
+#     project_name_or_id: str = ARG_PROJECT_NAME_OR_ID,
 #     name: str = typer.Option(..., "--name"),
 #     description: Optional[str] = typer.Option(..., "--description"),
 # ) -> None:
@@ -142,11 +136,10 @@ def get_webhook_policy(
 @policy_cmd.command("delete")
 def delete_webhook_policy(
     ctx: typer.Context,
-    project_name: Optional[str] = ARG_PROJECT_NAME,
+    project_name_or_id: str = ARG_PROJECT_NAME_OR_ID,
     policy_id: int = typer.Option(..., help="ID of the webhook policy to delete."),
-    project_id: Optional[int] = OPTION_PROJECT_ID,
 ) -> None:
     """Delete a webhook policy."""
-    project_arg = get_project_arg(project_name, project_id)
+    project_arg = get_project_arg(project_name_or_id)
     result = state.run(state.client.delete_webhook_policy(project_arg, policy_id))
     render_result(result, ctx)

--- a/harbor_cli/utils/args.py
+++ b/harbor_cli/utils/args.py
@@ -310,9 +310,9 @@ def _get_id_name_arg(resource_type: str, resource_name: str) -> str | int:
     break access to those projects.
     """
     if PREFIX_ID in resource_name:
-        resource_name.partition(PREFIX_ID)[2]
+        resource_id = resource_name.partition(PREFIX_ID)[2]
         try:
-            return int(resource_name)
+            return int(resource_id)
         except ValueError:
             exit_err(f"Invalid {resource_type} ID: {resource_name} is not an integer.")
     else:

--- a/tests/utils/test_args.py
+++ b/tests/utils/test_args.py
@@ -15,6 +15,9 @@ from harbor_cli.utils.args import as_query
 from harbor_cli.utils.args import construct_query_list
 from harbor_cli.utils.args import create_updated_model
 from harbor_cli.utils.args import deconstruct_query_list
+from harbor_cli.utils.args import get_ldap_group_arg
+from harbor_cli.utils.args import get_project_arg
+from harbor_cli.utils.args import get_user_arg
 from harbor_cli.utils.args import model_params_from_ctx
 from harbor_cli.utils.args import parse_commalist
 from harbor_cli.utils.args import parse_key_value_args
@@ -284,3 +287,22 @@ def test_construct_query_list(values: List[str], expected: str, union: bool) -> 
 )
 def test_add_to_query(kwargs: dict[str, Any], query: str | None, expected: str) -> None:
     assert add_to_query(query, **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    "name_or_id,expected",
+    [
+        ("foo", "foo"),
+        ("0", "0"),
+        ("id:0", 0),
+        ("1", "1"),
+        ("id:1", 1),
+        ("123", "123"),
+        ("id:123", 123),
+    ],
+)
+def test__get_id_name_arg(name_or_id: str, expected: str | int) -> None:
+    # Test all functions that use _get_id_name_arg
+    assert get_project_arg(name_or_id) == expected
+    assert get_user_arg(name_or_id) == expected
+    assert get_ldap_group_arg(name_or_id) == expected


### PR DESCRIPTION
Closes #53, but extends to _all_ commands that can take a name or ID as the argument. This changes these commands by unifying name and ID arguments/options to a single argument that can take either of the two. 

ID's must be prefixed with `id:`, i.e. the argument `"id:123"` is parsed into the integer `123`, while the argument `"123"` is parsed into the string `"123"`. 