### PR TITLE
Generate command documentation pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,17 +37,5 @@ jobs:
       - name: Install hatch
         run: pip install hatch
 
-      - name: Generate CLI output data for mkdocs
-        run: hatch run docs:python docs/scripts/gen_cli_data.py
-
-      - name: Generate list of output formats
-        run: hatch run docs:python docs/scripts/gen_formats.py
-
-      - name: Generate list of CLI commands
-        run: hatch run docs:python docs/scripts/gen_command_list.py
-
-      - name: Generate list of global CLI options
-        run: hatch run docs:python docs/scripts/gen_cli_options.py
-
       - name: Build documentation and publish
         run: hatch run docs:mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ TODO
 
 # Auto generated files
 docs/data/**
+docs/commands/**
 
 # Overrides
 !tests/data/**

--- a/docs/scripts/common.py
+++ b/docs/scripts/common.py
@@ -2,7 +2,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
-DOC_PATH = Path(__file__).parent.parent
-DATA_PATH = DOC_PATH / "data"
-if not DATA_PATH.exists():
-    DATA_PATH.mkdir(parents=True)
+# Directory of all docs files
+DOC_DIR = Path(__file__).parent.parent
+
+# Directory of data files for Jinja2 templates
+DATA_DIR = DOC_DIR / "data"
+if not DATA_DIR.exists():
+    DATA_DIR.mkdir(parents=True)
+
+# Directory of Jinja2 templates
+TEMPLATES_DIR = DOC_DIR / "templates"
+
+# Directory of generated command doc pages
+COMMANDS_DIR = DOC_DIR / "commands"
+if not COMMANDS_DIR.exists():
+    COMMANDS_DIR.mkdir(parents=True)

--- a/docs/scripts/gen_cli_data.py
+++ b/docs/scripts/gen_cli_data.py
@@ -8,9 +8,14 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
+from pathlib import Path
 from typing import NamedTuple
 
-from common import DATA_PATH
+sys.path.append(Path(__file__).parent.as_posix())
+
+
+from common import DATA_DIR  # noqa
 
 # Set up environment variables for the CLI
 env = os.environ.copy()
@@ -27,12 +32,17 @@ class Command(NamedTuple):
 # List of commands to run
 COMMANDS = [
     Command(["harbor", "--help"], "help.txt"),
-    Command(["harbor", "scanner", "list", "--help"], "help_scanner.txt"),
     Command(["harbor", "sample-config"], "sample_config.toml"),
 ]
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Run the commands and save the output to files."""
     for cmd in COMMANDS:
         output = subprocess.check_output(cmd.command, env=env).decode("utf-8")
-        with open(DATA_PATH / cmd.filename, "w") as f:
+        with open(DATA_DIR / cmd.filename, "w") as f:
             f.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/gen_cli_options.py
+++ b/docs/scripts/gen_cli_options.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import NamedTuple
 from typing import Sequence
 
 import yaml  # type: ignore
-from common import DATA_PATH
 
 from harbor_cli.deprecation import Deprecated
 from harbor_cli.main import app
 from harbor_cli.utils.commands import get_app_callback_options
+
+sys.path.append(Path(__file__).parent.as_posix())
+from common import DATA_DIR  # noqa
 
 
 def maybe_list_to_str(text: str | list[str] | None) -> str | None:
@@ -40,7 +44,7 @@ class OptInfo(NamedTuple):
         }
 
 
-if __name__ == "__main__":
+def main() -> None:
     options = []  # type: list[OptInfo]
     for option in get_app_callback_options(app):
         if not option.param_decls:
@@ -59,5 +63,9 @@ if __name__ == "__main__":
 
     to_dump = [o.to_dict() for o in options]
 
-    with open(DATA_PATH / "options.yaml", "w") as f:
+    with open(DATA_DIR / "options.yaml", "w") as f:
         yaml.dump(to_dump, f, sort_keys=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/gen_command_list.py
+++ b/docs/scripts/gen_command_list.py
@@ -1,18 +1,40 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+
 import yaml  # type: ignore
-from common import DATA_PATH
 
 from harbor_cli.main import app
 from harbor_cli.utils.commands import get_app_commands
 
 
-if __name__ == "__main__":
+sys.path.append(Path(__file__).parent.as_posix())
+from common import DATA_DIR  # noqa
+
+
+def main() -> None:
     commands = get_app_commands(app)
     command_names = [c.name for c in commands]
 
-    with open(DATA_PATH / "commands.txt", "w") as f:
-        f.write("\n".join(command_names))
+    categories: Dict[str, List[Dict[str, Any]]] = {}
+    for command in commands:
+        category = command.category or ""
+        if category not in categories:
+            categories[category] = []
+        cmd_dict = command.dict()
+        cmd_dict["usage"] = command.usage
+        categories[category].append(cmd_dict)
 
-    with open(DATA_PATH / "commands.yaml", "w") as f:
+    with open(DATA_DIR / "commands.yaml", "w") as f:
+        yaml.dump(categories, f, sort_keys=False)
+
+    with open(DATA_DIR / "commandlist.yaml", "w") as f:
         yaml.dump(command_names, f, sort_keys=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/gen_command_pages.py
+++ b/docs/scripts/gen_command_pages.py
@@ -1,0 +1,95 @@
+"""Generate the code reference pages and navigation."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict
+from typing import List
+
+import jinja2
+import yaml  # type: ignore
+from sanitize_filename import sanitize
+
+from harbor_cli.main import app
+from harbor_cli.models import CommandSummary
+from harbor_cli.utils.commands import get_app_commands
+
+sys.path.append(Path(__file__).parent.as_posix())
+sys.path.append(Path(__file__).parent.parent.parent.as_posix())
+
+from common import COMMANDS_DIR  # noqa
+from common import DATA_DIR  # noqa
+from common import TEMPLATES_DIR  # noqa
+
+
+# for path in sorted(SRC_PATH.rglob("*.py")):
+#     module_path = path.relative_to(Path(".").resolve()).with_suffix("")
+#     doc_path = path.relative_to(SRC_PATH).with_suffix(".md")
+#     full_doc_path = Path(DOC_DIR / "reference", doc_path)
+
+#     parts = tuple(module_path.parts)
+
+#     if parts[-1] == "__init__":
+#         parts = parts[:-1]
+#         doc_path = doc_path.with_name("index.md")
+#         full_doc_path = full_doc_path.with_name("index.md")
+#     elif parts[-1] == "__main__":
+#         continue
+
+#     nav[parts] = doc_path.as_posix()
+
+#     with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+#         ident = ".".join(parts)
+#         fd.write(f"::: {ident}")
+
+#     mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
+
+
+def gen_command_list(commands: list[CommandSummary]) -> None:
+    command_names = [c.name for c in commands]
+    with open(DATA_DIR / "commandlist.yaml", "w") as f:
+        yaml.dump(command_names, f, sort_keys=False)
+
+
+def gen_command_pages(commands: list[CommandSummary]) -> None:
+    categories: Dict[str, List[CommandSummary]] = {}
+    for command in commands:
+        category = command.category or command.name
+        if category not in categories:
+            categories[category] = []
+        categories[category].append(command)
+
+    loader = jinja2.FileSystemLoader(searchpath=TEMPLATES_DIR)
+    env = jinja2.Environment(loader=loader)
+
+    # nav = mkdocs_gen_files.Nav()
+
+    # Render each individual command page
+    pages = {}  # type: dict[str, str] # {category: filename}
+    for category_name, cmds in categories.items():
+        template = env.get_template("category.md.j2")
+        filename = sanitize(category_name.replace(" ", "_"))
+        filepath = COMMANDS_DIR / f"{filename}.md"
+        with open(filepath, "w") as f:
+            f.write(template.render(category=category_name, commands=cmds))
+        pages[category_name] = filename
+
+    # Render the command list page
+    template = env.get_template("command_list.md.j2")
+    template.render(pages=pages)
+    with open(COMMANDS_DIR / "index.md", "w") as f:
+        f.write(template.render(pages=pages))
+
+    # nav[]
+    # with mkdocs_gen_files.open("reference/SUMMARY.txt", "w") as nav_file:
+    #     nav_file.writelines(nav.build_literate_nav())
+
+
+def main() -> None:
+    commands = get_app_commands(app)
+    gen_command_list(commands)
+    gen_command_pages(commands)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/gen_formats.py
+++ b/docs/scripts/gen_formats.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import yaml  # type: ignore
-from common import DATA_PATH
 
 from harbor_cli.format import OutputFormat
 
+sys.path.append(Path(__file__).parent.as_posix())
 
-fmts = [fmt.value for fmt in OutputFormat]
+from common import DATA_DIR  # noqa
 
-with open(DATA_PATH / "formats.yaml", "w") as f:
-    yaml.dump(fmts, f, default_flow_style=False)
+
+def main() -> None:
+    fmts = [fmt.value for fmt in OutputFormat]
+
+    with open(DATA_DIR / "formats.yaml", "w") as f:
+        yaml.dump(fmts, f, default_flow_style=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/run.py
+++ b/docs/scripts/run.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(Path(__file__).parent.as_posix())
+
+from . import gen_cli_data  # noqa
+from . import gen_cli_options  # noqa
+from . import gen_command_list  # noqa
+from . import gen_command_pages  # noqa
+from . import gen_formats  # noqa
+
+for mod in [
+    gen_cli_data,
+    gen_cli_options,
+    gen_command_list,
+    gen_command_pages,
+    gen_formats,
+]:
+    mod.main()

--- a/docs/templates/category.md.j2
+++ b/docs/templates/category.md.j2
@@ -1,0 +1,75 @@
+{# Takes in a category and a list of CommandSummary objects #}
+{% if category | length > 0 %}
+# {{ category }}
+
+{% else %}
+
+# Top-level commands
+
+{% endif %}
+
+{% for command in commands %}
+## {{ command.name }}
+
+
+```
+{{ command.usage }}
+```
+
+{{ command.help_plain }}
+
+{# Only show this section if we have arguments #}
+{% set argument_params = command.params | selectattr('is_argument', 'equalto', true) | list %}
+{% if argument_params | length > 0 %}
+**Arguments**
+
+{% for param in command.params if param.is_argument %}
+&nbsp;&nbsp;&nbsp;&nbsp;**`{{ param.human_readable_name }}`**
+<br />&nbsp;&nbsp;&nbsp;&nbsp;{{ param.help_plain}}
+
+{% endfor %}
+
+{# End argument listing #}
+{% endif %}
+
+{# Only show this section if we have options #}
+{% set option_params = command.params | selectattr('is_argument', 'equalto', false) | list %}
+
+{% if option_params | length > 0 %}
+
+**Options**
+
+
+{% for param in command.params if not param.is_argument %}
+{% if param.opts | length > 0 %}
+&nbsp;&nbsp;&nbsp;&nbsp;{% for param in param.opts %} `{{ param }}`{% if not loop.last %}, {% endif %}{% endfor %} {% if not param.is_flag %}`<{{ param.human_readable_name }}>`{% endif %}<br />
+{% endif -%}
+&nbsp;&nbsp;&nbsp;&nbsp;{{ param.help_plain }}
+{%- if param.name == "query" -%}
+ See [harborapi docs](https://pederhan.github.io/harborapi/usage/methods/read/#query) for more information.
+{%- endif -%}
+<br />
+&nbsp;&nbsp;&nbsp;&nbsp;**Type:** {{ param.type}}<br />
+
+{%- if param.type == "choice" -%}
+&nbsp;&nbsp;&nbsp;&nbsp;**Choices:** {% for element in param.choices -%}{{ "`" + element + "`" if loop.first else ", `" + element + "`" }}{% endfor %}<br />
+{% endif %}
+
+{%- if param.default is not none -%}
+&nbsp;&nbsp;&nbsp;&nbsp;**Default:** `{{ param.default }}`<br />
+{%- endif %}
+
+
+
+
+
+{# End param loop #}
+{% endfor %}
+
+{# End params listing #}
+{% endif %}
+
+----
+
+{# End category commands loop #}
+{% endfor %}

--- a/docs/templates/command_list.md.j2
+++ b/docs/templates/command_list.md.j2
@@ -1,0 +1,5 @@
+# Categories
+
+{% for category, path in pages.items() -%}
+* [{{ category }}]({{ path }})
+{% endfor %}

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -8,6 +8,8 @@ For more information about a specific command, use:
 harbor <command> --help
 ```
 
+See [commands](../commands/index.md) for a list of all commands.
+
 
 ## Search for commands
 
@@ -17,13 +19,13 @@ To search for a command based on name or description, use:
 harbor find QUERY... [OPTIONS]
 ```
 
-See `harbor find --help` for more information.
+See [`harbor find`](../commands/find.md) for more information.
 
 
-## Command list
+## List of commands
 
 ```
-{% for command in commandlist %}
+{% for command in commandlist -%}
 {{ command }}
-{%- endfor %}
+{% endfor %}
 ```

--- a/harbor_cli/commands/api/artifact.py
+++ b/harbor_cli/commands/api/artifact.py
@@ -241,11 +241,13 @@ def get(
         False,
         "--with-vuln",
         "-v",
+        help="Include vulnerability report in output.",
     ),
     with_vuln_descriptions: bool = typer.Option(
         False,
         "--with-vuln-desc",
         "-d",
+        help="Include descriptions of each vulnerability in the output.",
     )
     # TODO: --tag
 ) -> None:
@@ -829,7 +831,7 @@ def list_artifact_vulnerabilities_summary(
     repo: List[str] = typer.Option(
         [],
         "--repo",
-        help="Repository name(s).",
+        help="Repository name(s). Should not include project name.",
         callback=parse_commalist,
     ),
     query: Optional[str] = OPTION_QUERY,

--- a/harbor_cli/commands/api/system.py
+++ b/harbor_cli/commands/api/system.py
@@ -33,12 +33,10 @@ def volumeinfo(ctx: typer.Context) -> None:
 
 @app.command("health")
 def health(ctx: typer.Context) -> None:
-    """Get system health.
-
-    NOTE: this is under the /health endpoint, not /system/health
-    but it is still a system health check, hence why it is here,
-    and not in its own health.py file.
-    """
+    """Get system health."""
+    # NOTE: this is under the /health endpoint, not /system/health
+    # but it is still a system health check, hence why it is here,
+    # and not in its own health.py file.
     health_status = state.run(state.client.health_check(), "Fetching health info...")
     render_result(health_status, ctx)
 

--- a/harbor_cli/commands/cli/find.py
+++ b/harbor_cli/commands/cli/find.py
@@ -105,7 +105,7 @@ def find_command(
         ),
     ),
 ) -> None:
-    """Search commands based on names and descriptions."""
+    """Search for commands based on names and descriptions."""
     matches = _do_find(
         ctx=ctx,
         query=query,

--- a/harbor_cli/commands/help.py
+++ b/harbor_cli/commands/help.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
 ARTIFACT_HELP_STRING = (
-    "Name of the artifact in the format '<project>/<repository><{:tag,@sha256:digest}>'. "
+    "Name of the artifact in the format 'PROJECT/REPOSITORY{:tag,@sha256:digest}'. "
     "Example: 'library/nginx:latest' or 'library/nginx@sha256:1234'"
 )

--- a/harbor_cli/models.py
+++ b/harbor_cli/models.py
@@ -7,21 +7,175 @@ Refactor to module (directory with __init__.py) if needed.
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
+from typing import List
+from typing import Optional
 
+from click.core import Argument
+from click.core import Parameter
 from harborapi.models import Project
 from harborapi.models.base import BaseModel as HarborAPIBaseModel
+from typer.core import TyperArgument
+from typer.core import TyperCommand
+
+from .utils.utils import markup_as_plain_text
 
 
 class BaseModel(HarborAPIBaseModel):
     pass
 
 
+def get(param: Any, attr: str) -> Any:
+    return getattr(param, attr, None)
+
+
+class ParamSummary(BaseModel):
+    """Serializable representation of a click.Parameter."""
+
+    allow_from_autoenv: Optional[bool] = None
+    confirmation_prompt: Optional[bool] = None
+    choices: Optional[List[str]] = None
+    count: Optional[bool] = None
+    default: Optional[Any] = None
+    envvar: Optional[str]
+    expose_value: bool
+    flag_value: Optional[Any] = None
+    help: str
+    hidden: Optional[bool] = None
+    human_readable_name: str
+    is_argument: bool
+    is_bool_flag: Optional[bool] = None
+    is_flag: Optional[bool] = None
+    is_option: Optional[bool]
+    metavar: Optional[str]
+    multiple: bool
+    name: str
+    nargs: int
+    prompt: Optional[str] = None
+    prompt_required: Optional[bool] = None
+    required: bool
+    show_choices: Optional[bool] = None
+    show_default: Optional[bool] = None
+    show_envvar: Optional[bool] = None
+    type: str
+    value_from_envvar: Any
+
+    @classmethod
+    def from_param(cls, param: Parameter) -> ParamSummary:
+        """Construct a new ParamSummary from a click.Parameter."""
+        try:
+            help_ = param.help or ""  # type: ignore
+        except AttributeError:
+            help_ = ""
+
+        is_argument = isinstance(param, (Argument, TyperArgument))
+        return cls(
+            argument=is_argument,
+            allow_from_autoenv=get(param, "allow_from_autoenv"),
+            confirmation_prompt=get(param, "confirmation_prompt"),
+            count=get(param, "count"),
+            choices=get(param.type, "choices"),
+            default=param.default,
+            envvar=param.envvar,
+            expose_value=param.expose_value,
+            flag_value=get(param, "flag_value"),
+            help=help_,
+            hidden=get(param, "hidden"),
+            human_readable_name=param.human_readable_name,
+            is_argument=is_argument,
+            is_bool_flag=get(param, "is_bool_flag"),
+            is_eager=param.is_eager,
+            is_flag=get(param, "is_flag"),
+            is_option=get(param, "is_option"),
+            metavar=param.metavar,
+            multiple=param.multiple,
+            name=param.name,
+            nargs=param.nargs,
+            opts=param.opts,
+            prompt=get(param, "prompt"),
+            prompt_required=get(param, "prompt_required"),
+            required=param.required,
+            secondary_opts=param.secondary_opts,
+            show_choices=get(param, "show_choices"),
+            show_default=get(param, "show_default"),
+            show_envvar=get(param, "show_envvar"),
+            type=param.type.name,
+        )
+
+    @property
+    def help_plain(self) -> str:
+        return markup_as_plain_text(self.help)
+
+
 # TODO: split up CommandSummary into CommandSummary and CommandSearchResult
 # so that the latter can have the score field
 class CommandSummary(BaseModel):
+    """Convenience class for accessing information about a command."""
+
     name: str
+    category: Optional[str] = None
     help: str
+    options_metavar: str
     score: int = 0  # match score
+    params: List[ParamSummary] = []
+
+    @classmethod
+    def from_command(
+        cls, command: TyperCommand, name: str | None = None, category: str | None = None
+    ) -> CommandSummary:
+        """Construct a new CommandSummary from a TyperCommand."""
+        return cls(
+            name=name or command.name or "",
+            category=category,
+            help=command.help or "",
+            options_metavar=command.options_metavar or "",
+            params=[ParamSummary.from_param(p) for p in command.params],
+        )
+
+    @property
+    def help_plain(self) -> str:
+        return markup_as_plain_text(self.help)
+
+    @property
+    def usage(self) -> str:
+        # TODO: determine if we should show metavar or not
+        # TODO: render required options!
+        parts = [self.name]
+
+        # Assume arg list is sorted by required/optional
+        # Show required in angle brackets, optional in square brackets
+        for arg in self.arguments:
+            metavar = arg.metavar or arg.human_readable_name
+            if arg.required:
+                parts.append(f"<{metavar}>")
+            else:
+                parts.append(f"[{metavar}]")
+
+        # Command with both required and optional options:
+        # `command <required_option> [OPTIONS]`
+        # Only required option(s):
+        # `command <required_option> <required_option>`
+        # Only optional options:
+        # `command [OPTIONS]`
+        has_optional = False
+        for option in self.options:
+            if option.required:
+                parts.append(f"<{option.metavar or option.human_readable_name}>")
+            else:
+                has_optional = True
+        else:
+            if has_optional:
+                parts.append("[OPTIONS]")
+
+        return " ".join(parts)
+
+    @property
+    def options(self) -> List[ParamSummary]:
+        return [p for p in self.params if not p.is_argument]
+
+    @property
+    def arguments(self) -> List[ParamSummary]:
+        return [p for p in self.params if p.is_argument]
 
 
 class ProjectExtended(Project):

--- a/harbor_cli/utils/utils.py
+++ b/harbor_cli/utils/utils.py
@@ -15,6 +15,7 @@ from typing import TypeVar
 
 from pydantic import BaseModel
 from pydantic import Extra
+from rich.text import Text
 
 MappingType = TypeVar("MappingType", bound=MutableMapping[str, Any])
 
@@ -171,3 +172,8 @@ def parse_version_string(package: str) -> PackageVersion:
     return PackageVersion(
         package_name, min_version=min_version, max_version=max_version
     )
+
+
+def markup_as_plain_text(s: str) -> str:
+    """Renders a string that might contain markup formatting as a plain text string."""
+    return Text.from_markup(s).plain

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,19 +17,24 @@ theme:
     - navigation.expand
     - navigation.indexes
 
+watch:
+  - harbor_cli
+
 plugins:
   - search
   - autorefs
+  - mkdocs-simple-hooks:
+      hooks:
+        on_pre_build: docs.scripts.run:main
+  - literate-nav: # enhanced nav section (enables wildcards)
   - macros:
       on_error_fail: true
       include_dir: "docs/data"
       include_yaml:
-        - commandlist: "docs/data/commands.yaml"
+        - commandlist: "docs/data/commandlist.yaml"
         - formats: "docs/data/formats.yaml"
         - options: "docs/data/options.yaml"
   - mkdocstrings:
-      watch:
-        - harbor_cli
       enable_inventory: true
       handlers:
         python:
@@ -59,7 +64,6 @@ markdown_extensions:
 nav:
   - "Home":
       - index.md
-      # - configuration.md
       - "Configuration":
           - configuration/introduction.md
           - configuration/config-file.md
@@ -71,8 +75,11 @@ nav:
           - usage/repl.md
           - usage/terminology.md
           # TODO: formats
+  - "Commands":
+      - "commands/*.md"
   - "Reference":
       - "reference/index.md"
+      - "reference/*.md"
       - "reference/config.md"
       - "reference/dirs.md"
       - "reference/exceptions.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,11 @@ dependencies = [
   "mkdocs-material",
   "mkdocstrings[python]",
   "mkdocs-macros-plugin",
+  "mkdocs-gen-files",
+  "mkdocs-literate-nav",
+  "mkdocs-simple-hooks",
+  "sanitize-filename",
+  "jinja2",
   "pyyaml",
 ]
 [tool.hatch.envs.docs.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ dependencies = [
   "mkdocs-material",
   "mkdocstrings[python]",
   "mkdocs-macros-plugin",
-  "mkdocs-gen-files",
   "mkdocs-literate-nav",
   "mkdocs-simple-hooks",
   "sanitize-filename",

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from harbor_cli.utils.utils import markup_as_plain_text
 from harbor_cli.utils.utils import PackageVersion
 from harbor_cli.utils.utils import parse_version_string
 from harbor_cli.utils.utils import replace_none
@@ -122,3 +123,20 @@ def test_replace_none_replacement(replacement: Any) -> None:
 )
 def test_parse_version_string(package: str, expected: PackageVersion) -> None:
     assert parse_version_string(package) == expected
+
+
+@pytest.mark.parametrize(
+    "inp,expected",
+    [
+        ("", ""),
+        ("[bold][/]", ""),
+        ("[bold][/bold]", ""),
+        ("This is a test", "This is a test"),
+        ("This is a [bold]test[/]", "This is a test"),
+        ("This is a [bold]test[/bold]", "This is a test"),
+        ("[italic]This is a [bold]test[/bold][/italic]", "This is a test"),
+        ("[italic]This is a [bold]test[/bold][/]", "This is a test"),
+    ],
+)
+def test_markup_as_plain_text(inp: str, expected: str) -> None:
+    assert markup_as_plain_text(inp) == expected


### PR DESCRIPTION
This PR adds automatic creation of docs pages for each command category. Each (sub)command group is counted as a category for this purpose. So `project metadata` is one category, while `project metadata field` is another. 

The style is inspired by the [GitHub CLI documentation](https://cli.github.com/manual/).

Furthermore, this PR makes use of 2 new mkdocs plugins to simplify the data file and template generation:

* `mkdocs-simple-hooks` to generate render the command templates before the documentation is built.
* `mkdocs-literate-nav` to add wildcard support for the `nav:` section of the config. This lets us specify `docs/commands/*.md` to automatically add all the generated pages.