### PR TITLE
Use `state.get_state()` instead of global object

### DIFF
--- a/harbor_cli/__init__.py
+++ b/harbor_cli/__init__.py
@@ -3,10 +3,4 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-# Import output to ensure it's loaded before attempting to load other modules
-# This is necessary to avoid circular imports due to the way the state object
-# is globally instantiated. The output methods use the state object to control
-# the console output
-from .output import *  # noreorder
-
 from . import *

--- a/harbor_cli/commands/api/artifact.py
+++ b/harbor_cli/commands/api/artifact.py
@@ -41,7 +41,7 @@ from ...output.prompts import check_enumeration_options
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
 from ...output.table._utils import get_table
-from ...state import state
+from ...state import get_state
 from ...style import render_cli_option
 from ...style import render_cli_value
 from ...style import render_warning
@@ -55,6 +55,9 @@ from ..help import ARTIFACT_HELP_STRING
 
 if TYPE_CHECKING:
     from ...utils.utils import PackageVersion  # noqa: F401
+
+
+state = get_state()
 
 
 # Create a command group

--- a/harbor_cli/commands/api/artifact.py
+++ b/harbor_cli/commands/api/artifact.py
@@ -59,7 +59,6 @@ if TYPE_CHECKING:
 
 state = get_state()
 
-
 # Create a command group
 app = typer.Typer(
     name="artifact",

--- a/harbor_cli/commands/api/auditlog.py
+++ b/harbor_cli/commands/api/auditlog.py
@@ -17,9 +17,12 @@ from harborapi.models import Schedule, ScheduleObj
 from ...style import render_cli_option, render_cli_value
 
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.commands import inject_resource_options
 from ...output.prompts import check_enumeration_options
+
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/cve_allowlist.py
+++ b/harbor_cli/commands/api/cve_allowlist.py
@@ -9,8 +9,11 @@ from harborapi.models.models import CVEAllowlistItem
 from ...logs import logger
 from ...output.console import exit
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils import parse_commalist
+
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/gc.py
+++ b/harbor_cli/commands/api/gc.py
@@ -11,10 +11,13 @@ from ...logs import logger
 from ...output.console import exit_err
 from ...output.prompts import check_enumeration_options
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import create_updated_model
 from ...utils.commands import inject_help
 from ...utils.commands import inject_resource_options
+
+state = get_state()
+
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/gc.py
+++ b/harbor_cli/commands/api/gc.py
@@ -18,7 +18,6 @@ from ...utils.commands import inject_resource_options
 
 state = get_state()
 
-
 # Create a command group
 app = typer.Typer(
     name="gc",

--- a/harbor_cli/commands/api/harbor_config.py
+++ b/harbor_cli/commands/api/harbor_config.py
@@ -10,9 +10,11 @@ from harborapi.models import ConfigurationsResponse
 from ...logs import logger
 from ...output.console import exit_err
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import model_params_from_ctx
 from ...utils.commands import inject_help
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/ldap.py
+++ b/harbor_cli/commands/api/ldap.py
@@ -12,7 +12,6 @@ from ...utils.commands import inject_help
 
 state = get_state()
 
-
 # Create a command group
 app = typer.Typer(
     name="ldap",

--- a/harbor_cli/commands/api/ldap.py
+++ b/harbor_cli/commands/api/ldap.py
@@ -6,9 +6,12 @@ import typer
 from harborapi.models.models import LdapConf
 
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import model_params_from_ctx
 from ...utils.commands import inject_help
+
+state = get_state()
+
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/project.py
+++ b/harbor_cli/commands/api/project.py
@@ -18,7 +18,7 @@ from ...output.console import exit_err
 from ...output.prompts import check_enumeration_options
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...style.style import render_cli_value
 from ...utils import parse_commalist
 from ...utils.args import create_updated_model
@@ -33,6 +33,8 @@ from ...utils.commands import ARG_USERNAME_OR_ID
 from ...utils.commands import inject_help
 from ...utils.commands import inject_resource_options
 from ...utils.commands import OPTION_FORCE
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/quotas.py
+++ b/harbor_cli/commands/api/quotas.py
@@ -9,10 +9,13 @@ from harborapi.models.models import QuotaUpdateReq
 
 from ...logs import logger
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import parse_commalist
 from ...utils.args import parse_key_value_args
 from ...utils.commands import inject_resource_options
+
+state = get_state()
+
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/quotas.py
+++ b/harbor_cli/commands/api/quotas.py
@@ -16,7 +16,6 @@ from ...utils.commands import inject_resource_options
 
 state = get_state()
 
-
 # Create a command group
 app = typer.Typer(
     name="quota",

--- a/harbor_cli/commands/api/registry.py
+++ b/harbor_cli/commands/api/registry.py
@@ -14,12 +14,15 @@ from ...output.console import exit_err
 from ...output.console import success
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import create_updated_model
 from ...utils.args import model_params_from_ctx
 from ...utils.commands import inject_help
 from ...utils.commands import inject_resource_options
 from ...utils.commands import OPTION_FORCE
+
+state = get_state()
+
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/registry.py
+++ b/harbor_cli/commands/api/registry.py
@@ -23,7 +23,6 @@ from ...utils.commands import OPTION_FORCE
 
 state = get_state()
 
-
 # Create a command group
 app = typer.Typer(
     name="registry",

--- a/harbor_cli/commands/api/replication.py
+++ b/harbor_cli/commands/api/replication.py
@@ -21,7 +21,6 @@ from ...utils.commands import OPTION_FORCE
 
 state = get_state()
 
-
 # Create a command group
 app = typer.Typer(
     name="replication",

--- a/harbor_cli/commands/api/replication.py
+++ b/harbor_cli/commands/api/replication.py
@@ -13,11 +13,14 @@ from ...logs import logger
 from ...output.prompts import check_enumeration_options
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import model_params_from_ctx
 from ...utils.commands import inject_help
 from ...utils.commands import inject_resource_options
 from ...utils.commands import OPTION_FORCE
+
+state = get_state()
+
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/repository.py
+++ b/harbor_cli/commands/api/repository.py
@@ -8,11 +8,13 @@ from harborapi.models.models import Repository
 from ...logs import logger
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.commands import inject_help
 from ...utils.commands import inject_resource_options
 from ...utils.commands import OPTION_FORCE
 
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/retention.py
+++ b/harbor_cli/commands/api/retention.py
@@ -11,12 +11,14 @@ from ...output.console import error
 from ...output.console import exit_err
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...style import render_cli_value
 from ...utils.args import get_project_arg
 from ...utils.commands import ARG_PROJECT_NAME_OR_ID_OPTIONAL
 from ...utils.commands import inject_resource_options
 from ...utils.commands import OPTION_FORCE
+
+state = get_state()
 
 app = typer.Typer(
     name="retention",

--- a/harbor_cli/commands/api/scan.py
+++ b/harbor_cli/commands/api/scan.py
@@ -10,7 +10,7 @@ from harborapi.models import ScanDataExportRequest
 from ...harbor.artifact import parse_artifact_name
 from ...logs import logger
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...style import render_cli_value
 from ...style.style import render_cli_command
 from ...utils.args import construct_query_list
@@ -18,6 +18,8 @@ from ...utils.args import parse_commalist
 from ...utils.args import parse_commalist_int
 from ..help import ARTIFACT_HELP_STRING
 from .project import get_project
+
+state = get_state()
 
 app = typer.Typer(
     name="scan",

--- a/harbor_cli/commands/api/scanall.py
+++ b/harbor_cli/commands/api/scanall.py
@@ -9,10 +9,13 @@ from harborapi.models import ScheduleObj
 from ...logs import logger
 from ...output.console import exit_err
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import create_updated_model
 from ...utils.args import model_params_from_ctx
 from ...utils.commands import inject_help
+
+state = get_state()
+
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/scanall.py
+++ b/harbor_cli/commands/api/scanall.py
@@ -16,7 +16,6 @@ from ...utils.commands import inject_help
 
 state = get_state()
 
-
 # Create a command group
 app = typer.Typer(
     name="scan-all",

--- a/harbor_cli/commands/api/scanner.py
+++ b/harbor_cli/commands/api/scanner.py
@@ -9,12 +9,14 @@ from harborapi.models.models import ScannerRegistrationReq
 from ...logs import logger
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import create_updated_model
 from ...utils.args import model_params_from_ctx
 from ...utils.commands import inject_help
 from ...utils.commands import inject_resource_options
 from ...utils.commands import OPTION_FORCE
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/search.py
+++ b/harbor_cli/commands/api/search.py
@@ -4,7 +4,10 @@ import typer
 
 from ...app import app
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
+
+
+state = get_state()
 
 
 @app.command()

--- a/harbor_cli/commands/api/system.py
+++ b/harbor_cli/commands/api/system.py
@@ -5,7 +5,9 @@ import time
 import typer
 
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/user.py
+++ b/harbor_cli/commands/api/user.py
@@ -13,7 +13,7 @@ from ...exceptions import HarborCLIError
 from ...logs import logger
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import create_updated_model
 from ...utils.args import get_user_arg
 from ...utils.commands import ARG_USERNAME_OR_ID
@@ -23,6 +23,9 @@ from ...utils.commands import OPTION_LIMIT
 from ...utils.commands import OPTION_PAGE
 from ...utils.commands import OPTION_PAGE_SIZE
 from ...utils.commands import OPTION_QUERY
+
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/usergroup.py
+++ b/harbor_cli/commands/api/usergroup.py
@@ -10,9 +10,11 @@ from ...models import UserGroupType
 from ...output.console import exit_err
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.commands import inject_resource_options
 from ...utils.commands import OPTION_FORCE
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/api/webhook.py
+++ b/harbor_cli/commands/api/webhook.py
@@ -6,10 +6,12 @@ import typer
 
 from ...output.prompts import check_enumeration_options
 from ...output.render import render_result
-from ...state import state
+from ...state import get_state
 from ...utils.args import get_project_arg
 from ...utils.commands import ARG_PROJECT_NAME_OR_ID
 from ...utils.commands import inject_resource_options
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(name="webhook", help="Manage webhooks", no_args_is_help=True)

--- a/harbor_cli/commands/cli/cache.py
+++ b/harbor_cli/commands/cli/cache.py
@@ -16,7 +16,9 @@ from ...output.console import console
 from ...output.console import info
 from ...output.render import render_result
 from ...output.table._utils import get_table
-from ...state import state
+from ...state import get_state
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(

--- a/harbor_cli/commands/cli/cli_config.py
+++ b/harbor_cli/commands/cli/cli_config.py
@@ -16,12 +16,15 @@ from ...output.console import success
 from ...output.formatting.path import path_link
 from ...output.render import render_result
 from ...output.table.anysequence import AnySequence
-from ...state import state
+from ...state import get_state
 from ...style import render_cli_command
 from ...style import render_cli_value
 from ...style import render_config_option
 from ...style.style import render_cli_option
 from ...utils.utils import forbid_extra
+
+
+state = get_state()
 
 # Create a command group
 app = typer.Typer(
@@ -40,9 +43,9 @@ def render_config(config: HarborCLIConfig, as_toml: bool) -> None:
 
 @app.callback()
 def callback(ctx: typer.Context) -> None:
-    # Every other command than "path" requires a config file
-    if ctx.invoked_subcommand != "path":
-        if state.config.config_file is None or not state.config_loaded:
+    # Every other command than "path" and "write" requires a config file
+    if ctx.invoked_subcommand not in ["path", "write"]:
+        if state.config.config_file is None or not state.is_config_loaded:
             exit_err(
                 "No configuration file loaded. A configuration file must exist to use this command."
             )
@@ -51,6 +54,8 @@ def callback(ctx: typer.Context) -> None:
 @app.command("get")
 def get_cli_config(
     ctx: typer.Context,
+    # TODO: Add support for fetching keys with dot notation
+    # key: str = typer.Argument(..., help="The config key to get."),
     as_toml: bool = typer.Option(
         True,
         "--toml/--no-toml",

--- a/harbor_cli/commands/cli/find.py
+++ b/harbor_cli/commands/cli/find.py
@@ -11,7 +11,7 @@ from fuzzywuzzy import fuzz
 from ...app import app
 from ...logs import logger
 from ...models import CommandSummary
-from ...output.render import render_result  # avoid circular import # TODO: fix
+from ...output.render import render_result
 from ...utils.commands import get_app_commands
 
 

--- a/harbor_cli/commands/cli/init.py
+++ b/harbor_cli/commands/cli/init.py
@@ -31,8 +31,11 @@ from ...output.prompts import bool_prompt
 from ...output.prompts import int_prompt
 from ...output.prompts import path_prompt
 from ...output.prompts import str_prompt
+from ...state import get_state
 from ...style import render_cli_option
 from ...style import STYLE_COMMAND
+
+state = get_state()
 
 
 TITLE_STYLE = "bold"  # Style for titles used by each config category
@@ -81,7 +84,6 @@ def init(
 
     if wizard:
         # fmt: off
-        from ...state import state
         config = run_config_wizard(config_path)
         state.config = config
         # fmt: on

--- a/harbor_cli/commands/cli/init.py
+++ b/harbor_cli/commands/cli/init.py
@@ -37,7 +37,6 @@ from ...style import STYLE_COMMAND
 
 state = get_state()
 
-
 TITLE_STYLE = "bold"  # Style for titles used by each config category
 MAIN_TITLE_STYLE = "bold underline"  # Style for the main title
 

--- a/harbor_cli/commands/cli/repl.py
+++ b/harbor_cli/commands/cli/repl.py
@@ -11,8 +11,10 @@ from ...app import app
 from ...config import DEFAULT_HISTORY_FILE
 from ...config import env_var
 from ...option import Option
-from ...state import state
+from ...state import get_state
 from ...style import render_cli_value
+
+state = get_state()
 
 
 @app.command()

--- a/harbor_cli/main.py
+++ b/harbor_cli/main.py
@@ -26,8 +26,10 @@ from .output.console import exit
 from .output.console import exit_err
 from .output.console import info
 from .output.formatting.path import path_link
+from .state import get_state
 from .state import State
-from .state import state
+
+state = get_state()
 
 # Init subcommand groups here
 for group in commands.ALL_GROUPS:
@@ -372,7 +374,7 @@ def main_callback(
         state.config.cache.enabled = cache_enabled
     if cache_ttl is not None:
         state.config.cache.ttl = cache_ttl
-    state.configure_cache()
+    state.configure_cache()  # NOTE: move to configure_from_config?
 
     # Set global options
     state.options.verbose = verbose
@@ -405,7 +407,7 @@ def try_load_config(config_file: Optional[Path], create: bool = True) -> None:
         Whether to create a new config file if one is not found, by default True
     """
     # Don't load the config if it's already loaded (e.g. in REPL)
-    if not state.config_loaded:
+    if not state.is_config_loaded:
         try:
             conf = HarborCLIConfig.from_file(config_file)
         except FileNotFoundError:

--- a/harbor_cli/output/formatting/builtin.py
+++ b/harbor_cli/output/formatting/builtin.py
@@ -5,10 +5,14 @@ from typing import Any
 from typing import Optional
 from typing import Sequence
 
-from ...state import state
+from ...state import get_state
 from ...style import EMOJI_NO
 from ...style import EMOJI_YES
+from .constants import FALSE_STR
 from .constants import NONE_STR
+from .constants import TRUE_STR
+
+state = get_state()
 
 
 def str_str(value: Optional[str]) -> str:
@@ -24,8 +28,9 @@ def bool_str(value: Optional[bool], none_is_false: bool = True) -> str:
         value = False
     if state.config.output.table.style.bool_emoji:
         return EMOJI_YES if value else EMOJI_NO
-    else:
-        return str(value).lower() if value is not None else NONE_STR
+    elif value is None:
+        return NONE_STR  # should we return None in emoji mode as well?
+    return TRUE_STR if value else FALSE_STR
 
 
 def float_str(value: Optional[float], precision: int = 2) -> str:

--- a/harbor_cli/output/formatting/constants.py
+++ b/harbor_cli/output/formatting/constants.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
 
 
-NONE_STR = "null"  # Matching JSON (for now)
+NONE_STR = "None"
+TRUE_STR = "True"
+FALSE_STR = "False"

--- a/harbor_cli/output/prompts.py
+++ b/harbor_cli/output/prompts.py
@@ -12,6 +12,8 @@ from rich.prompt import FloatPrompt
 from rich.prompt import IntPrompt
 from rich.prompt import Prompt
 
+from ..style.style import render_cli_option
+
 if TYPE_CHECKING:
     from ..config import HarborCLIConfig
     from ..state import State
@@ -280,6 +282,9 @@ def delete_prompt(
         if not bool_prompt(message, default=False):
             exit("Deletion aborted.")
     return
+
+
+ENUMERATION_WARNING = f"Unconstrained resource enumeration detected. It is recommended to use {render_cli_option('--query')} or {render_cli_option('--limit')} to constrain the results. Continue?"
 
 
 def check_enumeration_options(

--- a/harbor_cli/output/render.py
+++ b/harbor_cli/output/render.py
@@ -15,11 +15,14 @@ from pydantic import BaseModel
 from ..exceptions import OverwriteError
 from ..format import OutputFormat
 from ..logs import logger
-from ..state import state
+from ..state import get_state
 from .console import console
 from .table import BuiltinTypeException
 from .table import EmptySequenceError
 from .table import get_renderable
+
+
+state = get_state()
 
 T = TypeVar("T")
 

--- a/harbor_cli/output/table/_utils.py
+++ b/harbor_cli/output/table/_utils.py
@@ -8,8 +8,11 @@ from rich.console import RenderableType
 from rich.panel import Panel
 from rich.table import Table
 
-from ...state import state
+from ...state import get_state
 from ..formatting.builtin import plural_str
+
+
+state = get_state()
 
 
 def get_table(

--- a/harbor_cli/output/table/system.py
+++ b/harbor_cli/output/table/system.py
@@ -95,7 +95,7 @@ def generalinfo_panel(info: GeneralInfo, **kwargs) -> Panel:
             "Harbor Version",
             "Registry Storage Provider",
             "Read Only",
-            "Chart Museum",
+            "Nested Notary",
         ],
     )
     general_table.add_row(
@@ -104,7 +104,7 @@ def generalinfo_panel(info: GeneralInfo, **kwargs) -> Panel:
         str_str(info.harbor_version),
         str_str(info.registry_storage_provider_name),
         bool_str(info.read_only),
-        bool_str(info.with_chartmuseum),
+        bool_str(info.with_notary),
     )
     tables.append(general_table)
 

--- a/harbor_cli/utils/commands.py
+++ b/harbor_cli/utils/commands.py
@@ -5,7 +5,6 @@ import inspect
 from functools import lru_cache
 from typing import Any
 from typing import Type
-from typing import TYPE_CHECKING
 
 import click
 import typer
@@ -13,10 +12,8 @@ from pydantic import BaseModel
 from typer.core import TyperCommand
 from typer.core import TyperGroup
 
+from ..models import CommandSummary
 from ..style.style import render_cli_value
-
-if TYPE_CHECKING:
-    from ..models import CommandSummary
 
 
 def get_parent_ctx(
@@ -52,9 +49,6 @@ def _get_app_commands(
     cmds: list[CommandSummary] | None = None,
     current: str = "",
 ) -> list[CommandSummary]:
-    # Lazy-import to avoid circular imports
-    from ..models import CommandSummary
-
     if cmds is None:
         cmds = []
 
@@ -238,6 +232,10 @@ def _arg_project_name_or_id(default: Any = ...) -> Any:  # typer.Argument is unt
 
 ARG_PROJECT_NAME_OR_ID = _arg_project_name_or_id()
 ARG_PROJECT_NAME_OR_ID_OPTIONAL = _arg_project_name_or_id(None)
+ARG_REPO_NAME = typer.Argument(
+    ...,
+    help="Name of the repository to use.",
+)
 
 ARG_USERNAME_OR_ID = typer.Argument(
     ...,

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from enum import Enum
+from typing import Any
+from typing import Iterator
+from typing import NamedTuple
+from typing import Sequence
 
 import typer
+from rich.console import Console
+
+console = Console()
+err_console = Console(stderr=True, style="red")
 
 
 class VersionType(Enum):
@@ -47,6 +56,71 @@ versions = [v.value for v in VersionType]
 statuses = [s.value for s in StatusType]
 
 
+class State(Enum):
+    OLD_VERSION = 0  # before bumping version
+    NEW_VERSION = 1  # after bumping version
+    GIT_ADD = 2  # after git adding version file
+    GIT_COMMIT = 3  # after git commit
+    GIT_TAG = 4  # after git tag
+    GIT_PUSH = 5  # after git push
+
+    @classmethod
+    def __missing__(cls, value: Any) -> State:
+        return State.OLD_VERSION
+
+
+class StateMachine:
+    old_version: str | None = None
+    new_version: str | None = None
+
+    def __init__(self):
+        self.state = State.OLD_VERSION
+
+    def advance(self):
+        self.state = State(self.state.value + 1)
+
+    def revert(self) -> State:
+        self.state = State(self.state.value - 1)
+        return self.state
+
+    def rewind(self) -> Iterator[State]:
+        while self.state != State.OLD_VERSION:
+            yield self.revert()
+
+
+def set_version(version: str) -> str:
+    # We don't verify that the version arg is valid, we just pass it
+    # to hatch and let it handle it.
+    # Worst case scenario, we get a non-zero exit code and the script exits
+    p_version = subprocess.run(["hatch", "version", version])
+    if p_version.returncode != 0:
+        err_console.print(f"Failed to set version: {p_version.stderr.decode()}")
+        raise typer.Exit(1)
+    return p_version.stdout.decode().strip()  # the new version
+
+
+def cleanup(state: StateMachine) -> None:
+    for st in state.rewind():
+        # from last to first
+        # Best-effort cleanup
+        try:
+            if st == State.GIT_TAG:
+                if not state.new_version:
+                    raise ValueError("No new version to untag.")
+                subprocess.run(["git", "tag", "-d", state.new_version])
+            elif st == State.GIT_COMMIT:
+                subprocess.run(["git", "revert", "HEAD"])
+            elif st == State.GIT_ADD:
+                subprocess.run(["git", "reset", "HEAD"])
+            elif st == State.NEW_VERSION:
+                if not state.old_version:
+                    raise ValueError("No old version to revert to.")
+                # Revert the version bump
+                set_version(state.old_version)
+        except Exception as e:
+            print(f"Failed to revert state {state.state}: {e}", file=sys.stderr)
+
+
 def main(
     version: str = typer.Argument(
         ...,
@@ -64,23 +138,94 @@ def main(
 
     $ python bump_version.py 1.2.3 # generally don't use this
     """
-    # We don't verify that the arguments are valid, we just pass them
-    # to hatch and let it handle it.
-    # Worst case scenario, we get a non-zero exit code and the script exits
-    p_version = subprocess.run(["hatch", "version", version])
-    if p_version.returncode != 0:
-        typer.echo(f"Failed to bump version: {p_version.stderr.decode()}")
-        raise typer.Exit(1)
+    state = StateMachine()
+    try:
+        _main(version, state)
+    except Exception as e:
+        cleanup(state)
+        raise e
+
+
+class CommandCheck(NamedTuple):
+    program: str
+    command: Sequence[str]
+    message: str
+
+
+REQUIRED_COMMANDS = [
+    CommandCheck(
+        program="Hatch",
+        command=["hatch", "--version"],
+        message="Hatch is not installed. Please install it with `pip install hatch`.",
+    ),
+    CommandCheck(
+        program="Git",
+        command=["git", "--version"],
+        message="Git is not installed. Please install it.",
+    ),
+]
+
+
+def _check_commands() -> None:
+    """Checks that we have the necessary programs installed and available"""
+    for command in REQUIRED_COMMANDS:
+        try:
+            subprocess.check_output(command.command)
+        except FileNotFoundError:
+            err_console.print(f"{command.message} :x:", style="bold red")
+            raise typer.Exit(1)
+        else:
+            console.print(f"{command.program} :white_check_mark:")
+
+
+def _main(version: str, state: StateMachine) -> None:
+    _check_commands()
+
+    old_version = subprocess.check_output(["hatch", "version"])
+    state.old_version = old_version.decode().strip()
+
+    set_version(version)
+    state.advance()
+    assert state.state == State.NEW_VERSION
 
     # If this fails, something is very wrong.
     new_version = subprocess.check_output(["hatch", "version"]).decode().strip()
-    typer.echo(f"New version: {new_version}")
+    err_console.print(f"New version: {new_version}")
+    state.new_version = new_version
+
+    # Create a new commit with the changed version file
+    p_git_add = subprocess.run(["git", "add", "harbor_cli/__about__.py"])
+    if p_git_add.returncode != 0:
+        err_console.print(f"Failed to add version file: {p_git_add.stderr.decode()}")
+        raise typer.Exit(1)
+    state.advance()
+    assert state.state == State.GIT_ADD
+
+    p_git_commit = subprocess.run(
+        ["git", "commit", "-m", f"Bump version to {new_version}"]
+    )
+    if p_git_commit.returncode != 0:
+        err_console.print(
+            f"Failed to commit version bump: {p_git_commit.stderr.decode()}"
+        )
+        raise typer.Exit(1)
+    state.advance()
+    assert state.state == State.GIT_COMMIT
 
     tag = f"harbor-cli-v{new_version}"
     p_git_tag = subprocess.run(["git", "tag", tag])
     if p_git_tag.returncode != 0:
-        typer.echo(f"Failed to tag version: {p_git_tag.stderr.decode()}")
+        err_console.print(f"Failed to tag version: {p_git_tag.stderr.decode()}")
         raise typer.Exit(1)
+    state.advance()
+    assert state.state == State.GIT_TAG
+
+    p_git_push = subprocess.run(["git", "push", "--tags", "origin", "main"])
+    if p_git_push.returncode != 0:
+        err_console.print(f"Failed to push new version: {p_git_push.stderr.decode()}")
+        raise typer.Exit(1)
+    state.advance()
+    assert state.state == State.GIT_PUSH
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,14 +20,11 @@ from pydantic import BaseModel
 from typer.testing import CliRunner
 from typer.testing import Result
 
-from harbor_cli.main import app as main_app  # noreorder
-
-# We can't import these before main is imported, because of circular imports
+from ._strategies import COMPACT_TABLE_MODELS
+from harbor_cli import state
 from harbor_cli.config import HarborCLIConfig
 from harbor_cli.format import OutputFormat
-from harbor_cli import state
-
-from ._strategies import COMPACT_TABLE_MODELS
+from harbor_cli.main import app as main_app
 
 runner = CliRunner()
 
@@ -52,7 +49,7 @@ def config() -> HarborCLIConfig:
     # These are required to run commands
     conf.harbor.url = "https://harbor.example.com/api/v2.0"
     conf.harbor.username = "admin"
-    conf.harbor.secret = "password"
+    conf.harbor.secret = "password"  # type: ignore
     return conf
 
 
@@ -123,14 +120,14 @@ def output_format_arg(output_format: OutputFormat) -> list[str]:
     return ["--format", output_format.value]
 
 
-_ORIGINAL_STATE = copy(state.state)
+_ORIGINAL_STATE = copy(state.get_state())
 
 
 @pytest.fixture(scope="function", autouse=True)
 def revert_state() -> Generator[None, None, None]:
     """Reverts the global state back to its original value after the test is run."""
     yield
-    state.state = _ORIGINAL_STATE
+    state._STATE = _ORIGINAL_STATE
 
 
 @pytest.fixture

--- a/tests/output/formatting/test_builtin.py
+++ b/tests/output/formatting/test_builtin.py
@@ -11,18 +11,25 @@ from harbor_cli.output.formatting.builtin import float_str
 from harbor_cli.output.formatting.builtin import int_str
 from harbor_cli.output.formatting.builtin import NONE_STR
 from harbor_cli.output.formatting.builtin import plural_str
-from harbor_cli.state import state
+from harbor_cli.output.formatting.constants import FALSE_STR
+from harbor_cli.output.formatting.constants import TRUE_STR
+from harbor_cli.state import get_state
 from harbor_cli.style import EMOJI_NO
 from harbor_cli.style import EMOJI_YES
+
+
+state = get_state()
 
 
 @pytest.mark.parametrize(
     "inp,expected,none_is_false,as_emoji",
     [
-        (True, "true", False, False),
-        (False, "false", False, False),
+        # Text
+        (True, TRUE_STR, False, False),
+        (False, FALSE_STR, False, False),
         (None, NONE_STR, False, False),
-        (None, "false", True, False),
+        (None, FALSE_STR, True, False),
+        # Emoji
         (True, EMOJI_YES, False, True),
         (False, EMOJI_NO, False, True),
         (None, EMOJI_NO, False, True),
@@ -52,7 +59,9 @@ def test_float_str(inp: float, expected: str, precision: int) -> None:
 @pytest.mark.parametrize(
     "inp,expected",
     [
+        (0, "0"),
         (1, "1"),
+        (1234, "1234"),
         (None, NONE_STR),
     ],
 )

--- a/tests/output/test_render.py
+++ b/tests/output/test_render.py
@@ -16,7 +16,6 @@ from harbor_cli.state import get_state
 
 state = get_state()
 
-
 # The actual testing of the render functions is done in test_render_<format>()
 def test_render_result_json(mocker: MockerFixture) -> None:
     """Test that we can render a result."""

--- a/tests/output/test_render.py
+++ b/tests/output/test_render.py
@@ -12,7 +12,9 @@ from harbor_cli.output import render
 from harbor_cli.output.render import render_json
 from harbor_cli.output.render import render_result
 from harbor_cli.output.render import render_table
-from harbor_cli.state import state
+from harbor_cli.state import get_state
+
+state = get_state()
 
 
 # The actual testing of the render functions is done in test_render_<format>()


### PR DESCRIPTION
This pull request removes the module-level instantiation of the `State` object in `harbor_cli.state`. This resolves most current circular import issues, and removes the need to perform imports in a specific order in `__init__.py` and `conftest.py` files. Certain imports are still performed inside methods in `State`, but this is fine for now.

Closes #29 