### PR TITLE
Fix user input (prompts) tests

### DIFF
--- a/harbor_cli/config.py
+++ b/harbor_cli/config.py
@@ -143,7 +143,7 @@ class HarborSettings(BaseModel):
             return None
         return v
 
-    @validator("credentials_file")
+    @validator("credentials_file", always=True)
     def _validate_credentials_file(cls, v: Path | None) -> Path | None:
         if v is not None:
             if not v.exists():

--- a/harbor_cli/state.py
+++ b/harbor_cli/state.py
@@ -13,11 +13,12 @@ from rich.console import Console
 
 # This module generally shouldn't import from other local modules
 # because it's widely used throughout the application, and we don't want
-# to create circular import issues.
+# to create circular import issues. It sucks, but it's the way it is.
 
 if TYPE_CHECKING:
     from .config import HarborCLIConfig
     from .cache import Cache
+
 
 T = TypeVar("T")
 
@@ -111,11 +112,16 @@ class State:
     def config(self) -> HarborCLIConfig:
         """The current program configuration.
 
-        Returns the default config if no config is loaded.
+        Returns a default config if no config is loaded.
+        The default config is just a placeholder that is expected
+        to be replaced with a custom config loaded from a config file.
         """
+        # fmt: off
         if self._config is None:
-            return HarborCLIConfig()
+            from .config import HarborCLIConfig
+            self._config = HarborCLIConfig()
         return self._config
+        # fmt: on
 
     @config.setter
     def config(self, config: HarborCLIConfig) -> None:
@@ -137,7 +143,7 @@ class State:
         """Rich console object."""
         # fmt: off
         if not self._console:
-            from .output.console import console # lazy load the console
+            from .output.console import console
             self._console = console
         return self._console
         # fmt: on
@@ -180,8 +186,6 @@ class State:
             logger.warning(
                 "Harbor authentication method is missing or incomplete in configuration file."
             )
-            # TODO: refactor this so we can re-use username and password
-            # prompts from commands.cli.init!
             username, secret = prompt_username_secret(
                 self.config.harbor.username,
                 self.config.harbor.secret.get_secret_value(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
   "pytest>=7.2.0",
   "pytest-cov>=4.0.0",
   "pytest-mock>=3.10.0",
+  "pytest-timeout>=2.1.0",
   "mypy>=0.991",
   "black>=22.10.0",
   "hypothesis>=6.62.1",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import io
+import os
+from base64 import b64encode
 
 import pytest
+from harborapi import HarborAsyncClient
 
-if TYPE_CHECKING:
-    from harbor_cli.state import State
+from harbor_cli.config import HarborCLIConfig
+from harbor_cli.output.console import console
+from harbor_cli.state import State
 
 
 def test_state_run_nohandle(state: State) -> None:
@@ -19,3 +23,123 @@ def test_state_run_nohandle(state: State) -> None:
     # Tuple of error types
     with pytest.raises(ValueError):
         state.run(coro(), no_handle=(ValueError, TypeError))
+
+
+@pytest.mark.timeout(1)  # timeout to avoid hanging on prompt
+@pytest.mark.parametrize(
+    "url",
+    ["", "https://harbor.example.com/api/v2.0"],
+)
+@pytest.mark.parametrize(
+    "username",
+    ["username", ""],
+)
+@pytest.mark.parametrize(
+    "secret",
+    ["secret123", ""],
+)
+def test_state_init_client(
+    # state: State,
+    monkeypatch: pytest.MonkeyPatch,
+    # Fixture parameters
+    url: str,
+    username: str,
+    secret: str,
+) -> None:
+    # This test uses the state parameter because we need the config
+    # to be loaded, so that we can configure it.
+    # assert state.is_config_loaded
+    state = State()
+
+    state.config.harbor.url = url
+    state.config.harbor.username = username
+    state.config.harbor.secret = secret
+
+    # Explicitly clear the other auth methods
+    state.config.harbor.basicauth = ""
+    state.config.harbor.credentials_file = None
+
+    url_arg = url or "https://harbor.example.com/api/v2.0/default"
+    username_arg = username or "username_arg"
+    secret_arg = secret or "secret_arg"
+
+    stdin = []
+    if not url:
+        stdin.append(url_arg)
+        assert not state.config.harbor.url
+    if not username or not secret:
+        stdin.append(username_arg)
+        stdin.append(secret_arg)
+
+    sep = os.linesep
+    stdin_str = sep.join(stdin) + sep
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_str, newline=sep))
+
+    state._init_client()
+
+    # Test that we got prompted for the missing values and assigned to the client
+    # NOTE: we don't store this info in the config in State when we prompt this way.
+    # Should we do that?
+    assert state.client.url == url_arg
+    b = b64encode(f"{username_arg}:{secret_arg}".encode("utf-8")).decode("utf-8")
+    assert state.client.basicauth.get_secret_value() == b
+
+
+# Test properties that lazily initialize/assign values
+
+
+def test_state_console() -> None:
+    """Ensure that the console property uses the console object from harbor_cli.output.console"""
+    state = State()
+    assert state.console is console
+    new_state = State()
+    assert new_state.console is console
+
+
+def test_state_client() -> None:
+    """Ensure that the client property re-uses the same client object"""
+    state = State()
+    assert not state.is_client_loaded
+    default_client = state.client  # the default client
+
+    # Assign a client to the state to "load" it
+    client = HarborAsyncClient(
+        url="https://harbor.example.com/api/v2.0",
+        basicauth="username:secret",
+    )
+    state.client = client
+    assert state.is_client_loaded
+    assert state.client is client
+    assert state.client is not default_client
+
+    # Modify client and then retrieve it
+    state.client.basicauth = "username:secret"
+    state.client.basicauth == "username:secret"
+    assert state.client is client
+
+
+def test_state_config() -> None:
+    """Ensure that the client property re-uses the same client object"""
+    state = State()
+    assert not state.is_config_loaded
+    default_config = state.config  # the default config
+
+    # Assign a config to the state to "load" it
+    config = HarborCLIConfig()
+    state.config = config
+    assert state.is_config_loaded
+    assert state.config is config
+    assert state.config is not default_config
+
+    # Modify config and then retrieve it
+    state.config.harbor.url = "https://harbor.example.com/api/v2.0"
+    assert state.config is config
+    assert (
+        state.config.harbor.url
+        == config.harbor.url
+        == "https://harbor.example.com/api/v2.0"
+    )
+
+    # modify the config object directly (not through the state)
+    config.harbor.url = "https://example.com"
+    assert state.config.harbor.url == "https://example.com"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -71,7 +71,7 @@ def test_state_init_client(
         # on MacOS 12.6 (M1)
         # To work around this, we patch the underlying getpass._raw_input function
         monkeypatch.setattr(
-            "getpass._raw_input", lambda prompt, stream, input: secret_arg
+            "getpass._raw_input", lambda prompt="", stream=None, input=None: secret_arg
         )
         assert not state.config.harbor.has_auth_method
 


### PR DESCRIPTION
This PR aims to fix the various tests that mock user input via patching sys.stdin. These behave strangely both locally and and in CI, and I am not sure why. Probably something to do with the OS line separator character(s). They work flawlessly in the VSCode test runner which is very strange.