### PR TITLE
Add `tui` command

### DIFF
--- a/harbor_cli/commands/cli/__init__.py
+++ b/harbor_cli/commands/cli/__init__.py
@@ -9,6 +9,6 @@ from . import find as find
 from . import init as init
 from . import repl as repl
 from . import sample_config as sample_config
+from . import tui as tui
 
-# No subcommands for the CLI commands yet
 cli_commands: list[typer.Typer] = [cli_config.app, cache.app]

--- a/harbor_cli/commands/cli/tui.py
+++ b/harbor_cli/commands/cli/tui.py
@@ -5,6 +5,8 @@ from trogon import Trogon
 from typer.main import get_group
 
 from ...app import app
+from ...output.console import exit_err
+from ...state import get_state
 
 
 @app.command()
@@ -12,4 +14,9 @@ def tui(
     ctx: typer.Context,  # REPL options
 ) -> None:
     """Start a TUI (text-based user interface)."""
+    state = get_state()
+    if state.repl:
+        exit_err(
+            f"Cannot launch TUI from REPL mode. Exit REPL and run [italic]harbor tui[/italic]."
+        )
     Trogon(get_group(app), click_context=ctx, app_name="harbor").run()

--- a/harbor_cli/commands/cli/tui.py
+++ b/harbor_cli/commands/cli/tui.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import typer
+from trogon import Trogon
+from typer.main import get_group
+
+from ...app import app
+
+
+@app.command()
+def tui(
+    ctx: typer.Context,  # REPL options
+) -> None:
+    """Start a TUI (text-based user interface)."""
+    Trogon(get_group(app), click_context=ctx, app_name="harbor").run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,12 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "typer>=0.7.0",
+  "typer==0.9.0",
   "harborapi>=0.19.0",
   # "harborapi @ git+https://github.com/pederhan/harborapi.git@main",
   "trogon>=0.2.1",
   "pydantic>=1.10.2, <2.0.0",   # not yet sure if we can use 2.0.0 out of the box
+  "trogon>=0.3.0",
   "platformdirs>=2.5.4",
   "tomli>=2.0.1",
   "tomli-w>=1.0.0",
@@ -116,6 +117,7 @@ ignore = [
 ]
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402", "F401", "F403"]
+"harbor_cli/state.py" = ["E402"]
 
 [tool.mypy]
 python_version = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   "typer==0.9.0",
   "harborapi>=0.19.0",
   # "harborapi @ git+https://github.com/pederhan/harborapi.git@main",
-  "trogon>=0.2.1",
   "pydantic>=1.10.2, <2.0.0",   # not yet sure if we can use 2.0.0 out of the box
   "trogon>=0.3.0",
   "platformdirs>=2.5.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "typer>=0.7.0",
   "harborapi>=0.19.0",
   # "harborapi @ git+https://github.com/pederhan/harborapi.git@main",
+  "trogon>=0.2.1",
   "pydantic>=1.10.2, <2.0.0",   # not yet sure if we can use 2.0.0 out of the box
   "platformdirs>=2.5.4",
   "tomli>=2.0.1",


### PR DESCRIPTION
This PR adds a new command `tui`, which launches a TUI powered by [Trogon](https://github.com/Textualize/trogon). It works, but has some issues that should be resolved before merging. They are listed in the next section.

## Issues

- [x] `Optional[bool]` options default to their `False` state instead of being omitted (`None`)
  - **Example:** `--no-harbor-validate` is specified by default, when it should be omitted instead.
  - **Expected behavior:** These options should be omitted from command invocation instead of specifying their false option.
<img width="1065" alt="image" src="https://github.com/pederhan/harbor-cli/assets/107681714/c2b89243-fc6b-4774-b29a-3c9f0438242c">

*UI shows `--raw` being enabled despite `--no-raw` being present in the generated CLI command*

----

- [ ] Command arguments don't display any help text.
  - **Example:** `artifact buildhistory` requires an artifact as its first argument. The help text that is shown in the help output in the CLI is not shown in the TUI.
  - **Expected behavior:** Show same help text as in TUI (rich markup text).

<img width="1067" alt="image" src="https://github.com/pederhan/harbor-cli/assets/107681714/ecb2b803-ddd7-4285-ab22-6ed9bca5e454">

<img width="1057" alt="image" src="https://github.com/pederhan/harbor-cli/assets/107681714/4e3d6861-1735-45fe-9221-2b828f9a714e">


*TUI vs CLI `--help`*
 
----
  
These issues are upstream Trogon issues from what I can tell, and we will have to wait until it is fixed before we can reasonably merge this, as the defaults being applied to the main callback are disruptive enough to prohibit the `tui` command from being useful in its current state.