### PR TITLE
Use stdlib logging

### DIFF
--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -533,19 +533,17 @@ structlog = false
 
 #### `logging.level`
 
-The logging level to use. The default is `INFO`. The available logging levels are:
-
-- `TRACE`
+The logging level to use. The default is `WARNING`. The available logging levels are:
+`
 - `DEBUG`
 - `INFO`
-- `SUCCESS`
 - `WARNING`
 - `ERROR`
 - `CRITICAL`
 
 ```toml
 [logging]
-level = "INFO"
+level = "WARNING"
 ```
 
 #### `logging.directory`

--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -518,16 +518,6 @@ Whether or not to enable logging. The default is `true`.
 enabled = true
 ```
 
-----
-
-#### `logging.structlog`
-
-Whether or not to enable [structured logging](https://loguru.readthedocs.io/en/stable/overview.html#structured-logging-as-needed). The default is `false`.
-
-```toml
-[logging]
-structlog = false
-```
 
 ----
 

--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -505,7 +505,7 @@ ttl = 300
 
 ### `logging`
 
-The `logging` table contains settings related to configuring logging. Harbor CLI currently uses the [loguru](https://github.com/Delgan/loguru) logging library, but this might change in the future. None of the options pertain specifically to loguru, but are instead generic logging options.
+The `logging` table contains settings related to configuring logging. Logs are exclusively written to a log file and never displayed in the terminal. The default log directory is determined by [platformdirs.user_log_dir](https://pypi.org/project/platformdirs/).
 
 ----
 
@@ -554,6 +554,17 @@ Filename to use for log files. Can be automatically timed by adding `{time}` to 
 ```toml
 [logging]
 filename = "harbor_cli_{time}.log"
+```
+
+----
+
+#### `logging.timeformat`
+
+The time format that is used when automatically timing log files. Defaults to `"%Y-%m-%d"`. See [Python's strftime documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) for more information on how to format the time.
+
+```toml
+[logging]
+timeformat = "%Y-%m-%d"
 ```
 
 ----

--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -207,6 +207,15 @@ Whether or not to show a confirmation prompt when deleting resources unless `--f
 confirm_deletion = true
 ```
 
+#### `general.warnings`
+
+Show warning messages in terminal. Warnings are always logged regardless of this option. The default is `true`.
+
+```toml
+[general]
+warnings = true
+```
+
 ----
 
 ### `output`

--- a/harbor_cli/__init__.py
+++ b/harbor_cli/__init__.py
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
+from . import logs  # noreorder # configure logger first as side-effect
 from . import *

--- a/harbor_cli/commands/api/artifact.py
+++ b/harbor_cli/commands/api/artifact.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from enum import Enum
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -11,6 +10,7 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import TYPE_CHECKING
+from typing import Union
 
 import typer
 from harborapi.exceptions import NotFound
@@ -25,6 +25,7 @@ from harborapi.models import Tag
 from harborapi.models.scanner import Severity
 from pydantic import BaseModel as PydanticBaseModel
 from rich.table import Table
+from strenum import StrEnum
 
 from ...harbor.artifact import get_artifact_architecture
 from ...harbor.artifact import get_artifact_os
@@ -33,8 +34,10 @@ from ...logs import logger
 from ...models import ArtifactVulnerabilitySummary
 from ...models import BaseModel
 from ...models import Operator
+from ...output.console import error
 from ...output.console import exit
 from ...output.console import exit_err
+from ...output.console import info
 from ...output.console import warning
 from ...output.prompts import bool_prompt
 from ...output.prompts import check_enumeration_options
@@ -175,7 +178,7 @@ def list_artifacts(
         results = [a for a in results if get_artifact_os(a.artifact) in os]
 
     render_result(results, ctx)
-    logger.info(f"Fetched {len(results)} artifact(s).")
+    info(f"Fetched {len(results)} artifact(s).")
 
 
 # delete_artifact()
@@ -200,7 +203,7 @@ def delete_artifact(
     except NotFound:
         exit_err(f"Artifact {artifact} not found.")
     else:
-        logger.info(f"Artifact {artifact} deleted.")
+        info(f"Artifact {artifact} deleted.")
 
 
 # copy_artifact()
@@ -225,10 +228,10 @@ def copy_artifact(
     # Warn user if they pass a project name in the repository name
     # e.g. project="foo", repository="foo/bar"
     # When it should be project="foo", repository="bar"
+    # We can't prevent them from doing this in case this is a legitimate
+    # use case, but in most cases it won't be so we need to warn them
     if project in repository:
-        logger.warning(
-            "Project name is part of the repository name, you likely don't want this."
-        )
+        warning("Repository name contains project name, you likely don't want this.")
 
     try:
         resp = state.run(
@@ -238,7 +241,7 @@ def copy_artifact(
     except NotFound:
         exit_err(f"Artifact {artifact} not found.")
     else:
-        logger.info(f"Artifact {artifact} copied to {resp}.")
+        info(f"Artifact {artifact} copied to {resp}.")
 
 
 # HarborAsyncClient.get_artifact()
@@ -332,7 +335,7 @@ def create_artifact_tag(
         state.client.create_artifact_tag(an.project, an.repository, an.reference, t),
         f"Creating tag {tag!r} for {artifact}...",
     )
-    logger.info(f"Created {tag!r} for {artifact}: {location}")
+    info(f"Created {tag!r} for {artifact}: {location}")
 
 
 # delete_artifact_tag()
@@ -402,7 +405,7 @@ def add_artifact_label(
         state.client.add_artifact_label(an.project, an.repository, an.reference, label),
         f"Adding label {label.name!r} to {artifact}...",
     )
-    logger.info(f"Added label {label.name!r} to {artifact}.")
+    info(f"Added label {label.name!r} to {artifact}.")
 
 
 # HarborAsyncClient.delete_artifact_label()
@@ -469,7 +472,7 @@ def get_buildhistory(
     render_result(history, ctx, artifact=artifact)
 
 
-class DeletionReason(str, Enum):
+class DeletionReason(StrEnum):
     """Reasons for deleting an artifact."""
 
     AGE = "age"
@@ -502,14 +505,14 @@ class ArtifactDeletion:
         self.except_tag = except_tag
 
         # Construct a dictionary from the criteria passed in
-        self.criteria = {}
+        self.criteria = {}  # type: dict[str, bool]
         if age is not None:
             self.criteria[DeletionReason.AGE] = False
         if severity is not None:
             self.criteria[DeletionReason.SEVERITY] = False
 
     @property
-    def reasons(self) -> list[DeletionReason]:
+    def reasons(self) -> list[str]:
         return [k for k, v in self.criteria.items() if v]
 
     def should_delete(self) -> bool:
@@ -586,7 +589,7 @@ class ArtifactDeletion:
 class ScheduledArtifactDeletion(PydanticBaseModel):
     """Encapsulates an artifact deletion scheduled for a future time."""
 
-    artifacts: Dict[str, List[DeletionReason]]
+    artifacts: Dict[str, List[Union[DeletionReason, str]]]
 
     def __rich_console__(self, console, options) -> Table:  # type: ignore
         from ...output.table._utils import get_table
@@ -701,7 +704,7 @@ def cleanup_artifacts(
                 )
             to_delete.append(d)
             logger.debug(
-                f"Scheduling {artifact.name_with_digest} for deletion. Reason(s): {', '.join(reason.value for reason in d.reasons)}",
+                f"Scheduling {artifact.name_with_digest} for deletion. Reason(s): {', '.join(reason for reason in d.reasons)}",
                 extra=dict(artifact=artifact.name_with_digest, reasons=d.criteria),
             )
 
@@ -717,7 +720,7 @@ def cleanup_artifacts(
         }
     )
 
-    logger.info(f"Will delete {len(to_delete)} artifacts:")
+    info(f"Will delete {len(to_delete)} artifacts:")
     render_result(res, ctx)
 
     if dry_run:
@@ -737,7 +740,7 @@ def cleanup_artifacts(
                 ),
                 f"Deleting {deletion.artifact.name_with_digest}...",
             )
-            logger.info(f"Deleted {artifact.name_with_digest}")
+            info(f"Deleted {artifact.name_with_digest}")
         except Exception as e:
             msg = f"Failed to delete {artifact.name_with_digest}: {e}"
             kwargs = {
@@ -747,7 +750,7 @@ def cleanup_artifacts(
             if exit_on_error:
                 exit_err(msg, **kwargs)  # type: ignore # wrong mypy err? this isn't argument 2
             else:
-                logger.error(msg, extra=dict(**kwargs))
+                error(msg, **kwargs, exc_info=True)
 
 
 class AffectedArtifact(BaseModel):
@@ -824,14 +827,14 @@ class AffectedArtifactList(BaseModel):
         yield table
 
 
-class ArtifactSummarySorting(str, Enum):
+class ArtifactSummarySorting(StrEnum):
     total = "total"
     severity = "severity"
     name = "name"
     age = "age"
 
 
-class SortOrder(str, Enum):
+class SortOrder(StrEnum):
     asc = "asc"
     desc = "desc"
 
@@ -857,13 +860,13 @@ def list_artifact_vulnerabilities_summary(
     ),
     query: Optional[str] = OPTION_QUERY,
     sort: ArtifactSummarySorting = typer.Option(
-        ArtifactSummarySorting.total.value,
+        ArtifactSummarySorting.total,
         "--sort",
         help="Artifact attribute to sort by.",
         case_sensitive=False,
     ),
     order: SortOrder = typer.Option(
-        SortOrder.desc.value,
+        SortOrder.desc,
         "--order",
         help="Sorting order of artifacts.",
         case_sensitive=False,

--- a/harbor_cli/commands/api/artifact.py
+++ b/harbor_cli/commands/api/artifact.py
@@ -702,8 +702,7 @@ def cleanup_artifacts(
             to_delete.append(d)
             logger.debug(
                 f"Scheduling {artifact.name_with_digest} for deletion. Reason(s): {', '.join(reason.value for reason in d.reasons)}",
-                artifact=artifact.name_with_digest,
-                reasons=d.criteria,
+                extra=dict(artifact=artifact.name_with_digest, reasons=d.criteria),
             )
 
     if max_count and len(to_delete) > max_count:
@@ -738,10 +737,7 @@ def cleanup_artifacts(
                 ),
                 f"Deleting {deletion.artifact.name_with_digest}...",
             )
-            logger.info(
-                f"Deleted {artifact.name_with_digest}",
-                artifact=artifact.name_with_digest,
-            )
+            logger.info(f"Deleted {artifact.name_with_digest}")
         except Exception as e:
             msg = f"Failed to delete {artifact.name_with_digest}: {e}"
             kwargs = {
@@ -751,7 +747,7 @@ def cleanup_artifacts(
             if exit_on_error:
                 exit_err(msg, **kwargs)  # type: ignore # wrong mypy err? this isn't argument 2
             else:
-                logger.error(msg, **kwargs)
+                logger.error(msg, extra=dict(**kwargs))
 
 
 class AffectedArtifact(BaseModel):

--- a/harbor_cli/commands/api/cve_allowlist.py
+++ b/harbor_cli/commands/api/cve_allowlist.py
@@ -6,8 +6,8 @@ import typer
 from harborapi.models.models import CVEAllowlist
 from harborapi.models.models import CVEAllowlistItem
 
-from ...logs import logger
 from ...output.console import exit
+from ...output.console import info
 from ...output.render import render_result
 from ...state import get_state
 from ...utils import parse_commalist
@@ -69,13 +69,11 @@ def update_allowlist(
 
     state.run(state.client.update_cve_allowlist(current), "Updating CVE allowlist...")
     if remove:
-        logger.info(
+        info(
             f"Removed {len(cves)} CVEs from CVE allowlist. Total: {len(current.items)}"
         )
     else:
-        logger.info(
-            f"Added {len(cves)} CVEs to CVE allowlist. Total: {len(current.items)}"
-        )
+        info(f"Added {len(cves)} CVEs to CVE allowlist. Total: {len(current.items)}")
 
 
 @app.command("clear")
@@ -101,4 +99,4 @@ def clear_allowlist(
     msg = "Cleared CVE allowlist of CVEs."
     if full_clear:
         msg += " Also cleared metadata."
-    logger.info(msg)
+    info(msg)

--- a/harbor_cli/commands/api/gc.py
+++ b/harbor_cli/commands/api/gc.py
@@ -7,8 +7,8 @@ from harborapi.models.models import Schedule
 from harborapi.models.models import ScheduleObj
 from harborapi.models.models import Type as ScheduleType
 
-from ...logs import logger
 from ...output.console import exit_err
+from ...output.console import info
 from ...output.prompts import check_enumeration_options
 from ...output.render import render_result
 from ...state import get_state
@@ -66,7 +66,7 @@ def create_gc_schedule(
         state.client.create_gc_schedule(schedule),
         "Creating Garbage Collection schedule...",
     )
-    logger.info(f"Garbage Collection schedule created.")
+    info(f"Garbage Collection schedule created.")
 
 
 @schedule_cmd.command("update")
@@ -100,7 +100,7 @@ def update_gc_schedule(
         state.client.update_gc_schedule(schedule),
         f"Updating Garbage Collection schedule...",
     )
-    logger.info(f"Garbage Collection schedule updated.")
+    info(f"Garbage Collection schedule updated.")
 
 
 # HarborAsyncClient.get_gc_jobs()

--- a/harbor_cli/commands/api/harbor_config.py
+++ b/harbor_cli/commands/api/harbor_config.py
@@ -7,8 +7,8 @@ import typer
 from harborapi.models import Configurations
 from harborapi.models import ConfigurationsResponse
 
-from ...logs import logger
 from ...output.console import exit_err
+from ...output.console import info
 from ...output.render import render_result
 from ...state import get_state
 from ...utils.args import model_params_from_ctx
@@ -343,7 +343,7 @@ def update_config(
     """Update the Harbor configuration.
 
     One or more configuration parameters must be provided."""
-    logger.info("Updating configuration...")
+    info("Updating configuration...")
     params = model_params_from_ctx(ctx, Configurations)
     if not params:
         exit_err("No configuration parameters provided.")
@@ -366,4 +366,4 @@ def update_config(
         state.client.update_config(configuration),
         "Updating configuration...",
     )
-    logger.info("Configuration updated.")
+    info("Configuration updated.")

--- a/harbor_cli/commands/api/project.py
+++ b/harbor_cli/commands/api/project.py
@@ -10,11 +10,12 @@ from harborapi.models.models import ProjectMetadata
 from harborapi.models.models import ProjectReq
 from harborapi.models.models import RoleRequest
 
-from ...logs import logger
 from ...models import MemberRoleType
 from ...models import ProjectExtended
 from ...output.console import exit
 from ...output.console import exit_err
+from ...output.console import info
+from ...output.console import warning
 from ...output.prompts import check_enumeration_options
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
@@ -115,7 +116,7 @@ def get_project_logs(
         f"Fetching logs for {project_repr}...",
     )
     render_result(logs, ctx)
-    logger.info(f"Fetched {len(logs)} logs.")
+    info(f"Fetched {len(logs)} logs.")
 
 
 # HarborAsyncClient.project_exists()
@@ -225,7 +226,7 @@ def create_project(
         state.client.create_project(project_req), "Creating project..."
     )
     project_repr = get_project_repr(project_name)
-    logger.info(f"Created {project_repr}")
+    info(f"Created {project_repr}")
     res = ProjectCreateResult(location=location, project=project_req)
     render_result(res, ctx)
 
@@ -281,7 +282,7 @@ def list_projects(
         "Fetching projects...",
     )
     render_result(projects, ctx)
-    logger.info(f"Fetched {len(projects)} projects.")
+    info(f"Fetched {len(projects)} projects.")
 
 
 # HarborAsyncClient.update_project()
@@ -369,7 +370,7 @@ def update_project(
     req.metadata = metadata
 
     state.run(state.client.update_project(arg, req), f"Updating project...")
-    logger.info(f"Updated {get_project_repr(arg)}")
+    info(f"Updated {get_project_repr(arg)}")
 
 
 # HarborAsyncClient.delete_project()
@@ -384,7 +385,7 @@ def delete_project(
     delete_prompt(config=state.config, force=force, resource="project", name=str(arg))
     project_repr = get_project_repr(arg)
     state.run(state.client.delete_project(arg), f"Deleting {project_repr}...")
-    logger.info(f"Deleted {project_repr}.")
+    info(f"Deleted {project_repr}.")
 
 
 # HarborAsyncClient.get_project_summary()
@@ -429,7 +430,7 @@ def set_project_scanner(
     state.run(
         state.client.set_project_scanner(arg, scanner_id), f"Setting project scanner..."
     )
-    logger.info(f"Set scanner for {project_repr} to {scanner_repr}")
+    info(f"Set scanner for {project_repr} to {scanner_repr}")
 
 
 # HarborAsyncClient.get_project_scanner_candidates()
@@ -554,7 +555,7 @@ def set_project_metadata(
         state.client.set_project_metadata(arg, metadata),
         f"Setting metadata for {project_repr}...",
     )
-    logger.info(f"Set metadata for {project_repr}.")
+    info(f"Set metadata for {project_repr}.")
 
 
 # HarborAsyncClient.get_project_metadata_entry()
@@ -593,7 +594,7 @@ def set_project_metadata_field(
 ) -> None:
     """Set a single field in the metadata for a project."""
     if field not in ProjectMetadata.__fields__:
-        logger.warning(f"Field {field!r} is not a known project metadata field.")
+        warning(f"Field {field!r} is not a known project metadata field.")
 
     arg = get_project_arg(project_name_or_id)
     project_repr = get_project_repr(arg)
@@ -604,7 +605,7 @@ def set_project_metadata_field(
         state.client.update_project_metadata_entry(arg, field, metadata),
         f"Setting metadata for {project_repr}...",
     )
-    logger.info(f"Set metadata for {project_repr}.")
+    info(f"Set metadata for {project_repr}.")
 
 
 # HarborAsyncClient.delete_project_metadata_entry()
@@ -621,7 +622,7 @@ def delete_project_metadata_field(
     """Delete a single field in the metadata for a project."""
     delete_prompt(state.config, force, resource="metadata field", name=field)
     if field not in ProjectMetadata.__fields__:
-        logger.warning(f"Field {field!r} is not a known project metadata field.")
+        warning(f"Field {field!r} is not a known project metadata field.")
 
     arg = get_project_arg(project_name_or_id)
 
@@ -629,7 +630,7 @@ def delete_project_metadata_field(
         state.client.delete_project_metadata_entry(arg, field),
         f"Deleting metadata field {field!r}...",
     )
-    logger.info(f"Deleted metadata field {field!r}.")
+    info(f"Deleted metadata field {field!r}.")
 
 
 # HarborAsyncClient.get_project_member()
@@ -727,7 +728,7 @@ def remove_project_member(
         state.client.remove_project_member(project_arg, member_id),
         f"Removing member...",
     )
-    logger.info(f"Removed member {member_id} from project {project_arg}.")
+    info(f"Removed member {member_id} from project {project_arg}.")
 
 
 # HarborAsyncClient.get_project_members()

--- a/harbor_cli/commands/api/quotas.py
+++ b/harbor_cli/commands/api/quotas.py
@@ -7,7 +7,7 @@ import typer
 from harborapi.models.models import Quota
 from harborapi.models.models import QuotaUpdateReq
 
-from ...logs import logger
+from ...output.console import info
 from ...output.render import render_result
 from ...state import get_state
 from ...utils.args import parse_commalist
@@ -66,12 +66,12 @@ def update_quota(
     # quota = get_quota(quota_id)
     # FIXME: how to use existing quota?
 
-    req = QuotaUpdateReq(hard=props)
+    req = QuotaUpdateReq(hard=props)  # TODO: fix
     state.run(state.client.update_quota(quota_id, req), f"Updating quota...")
 
     # TODO: render quotas before and after update
     render_result(req, ctx)  # is this a good idea?
-    logger.info("Quota updated successfully.")
+    info("Quota updated successfully.")
 
 
 @app.command("list")

--- a/harbor_cli/commands/api/registry.py
+++ b/harbor_cli/commands/api/registry.py
@@ -9,8 +9,8 @@ from harborapi.models.models import RegistryCredential
 from harborapi.models.models import RegistryPing
 from harborapi.models.models import RegistryUpdate
 
-from ...logs import logger
 from ...output.console import exit_err
+from ...output.console import info
 from ...output.console import success
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
@@ -144,7 +144,7 @@ def update_registry(
     registry = get_registry(registry_id)
     req = create_updated_model(registry, RegistryUpdate, ctx)
     state.run(state.client.update_registry(registry_id, req), f"Updating registry...")
-    logger.info("Registry updated successfully.")
+    info("Registry updated successfully.")
 
 
 @app.command("delete", no_args_is_help=True)
@@ -159,7 +159,7 @@ def delete_registry(
     """Delete a registry."""
     delete_prompt(state.config, force, resource="registry", name=str(registry_id))
     state.run(state.client.delete_registry(registry_id), f"Deleting registry...")
-    logger.info(f"Deleted registry with ID {registry_id}.")
+    info(f"Deleted registry with ID {registry_id}.")
 
 
 @app.command("info", no_args_is_help=True)

--- a/harbor_cli/commands/api/replication.py
+++ b/harbor_cli/commands/api/replication.py
@@ -9,7 +9,7 @@ from harborapi.models.models import ReplicationPolicy
 from harborapi.models.models import ReplicationTrigger
 from harborapi.models.models import ReplicationTriggerSettings
 
-from ...logs import logger
+from ...output.console import info
 from ...output.prompts import check_enumeration_options
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
@@ -55,7 +55,7 @@ def start_replication_execution(
         state.client.start_replication(policy_id), "Starting replication..."
     )
     render_result(replication_url, ctx)
-    logger.info(f"Replication started for policy {policy_id}.")
+    info(f"Replication started for policy {policy_id}.")
 
 
 # HarborAsyncClient.stop_replication()
@@ -72,7 +72,7 @@ def stop_replication_execution(
         state.client.stop_replication(execution_id),
         f"Stopping replication execution...",
     )
-    logger.info(f"Stopped replication execution with ID {execution_id}.")
+    info(f"Stopped replication execution with ID {execution_id}.")
 
 
 # HarborAsyncClient.get_replication()
@@ -306,7 +306,7 @@ def create_replication_policy(
         state.client.create_replication_policy(policy),
         f"Creating replication policy {policy}...",
     )
-    logger.info(f"Created replication policy: {policy_url}.")
+    info(f"Created replication policy: {policy_url}.")
 
 
 # HarborAsyncClient.update_replication_policy()
@@ -350,7 +350,7 @@ def delete_replication_policy(
         state.client.delete_replication_policy(policy_id),
         f"Deleting replication policy with ID {policy_id}...",
     )
-    logger.info(f"Deleted replication policy with ID {policy_id}.")
+    info(f"Deleted replication policy with ID {policy_id}.")
 
 
 # HarborAsyncClient.get_replication_policies()
@@ -429,6 +429,6 @@ def get_task_log(
         "Fetching replication logs...",
     )
     render_result(log, ctx)
-    logger.info(
+    info(
         f"Fetched log for replication task {task_id} of replication execution {execution_id}"
     )

--- a/harbor_cli/commands/api/repository.py
+++ b/harbor_cli/commands/api/repository.py
@@ -5,7 +5,7 @@ from typing import Optional
 import typer
 from harborapi.models.models import Repository
 
-from ...logs import logger
+from ...output.console import info
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
 from ...state import get_state
@@ -75,7 +75,7 @@ def delete_artifact(
         ),
         "Deleting repository...",
     )
-    logger.info(f"Deleted {project}/{repository}.")
+    info(f"Deleted {project}/{repository}.")
 
 
 # HarborAsyncClient.update_repository()
@@ -100,7 +100,7 @@ def update_repository(
     repo = get_repository(project, repository)
     repo.description = description
     state.run(state.client.update_repository(project, repository, repo))
-    logger.info(f"Updated {project}/{repository}.")
+    info(f"Updated {project}/{repository}.")
 
 
 # HarborAsyncClient.get_repositories()

--- a/harbor_cli/commands/api/retention.py
+++ b/harbor_cli/commands/api/retention.py
@@ -6,9 +6,9 @@ import typer
 from harborapi.exceptions import StatusError
 from harborapi.models import RetentionPolicy
 
-from ...logs import logger
 from ...output.console import error
 from ...output.console import exit_err
+from ...output.console import info
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
 from ...state import get_state
@@ -165,14 +165,15 @@ def delete_retention_policy(
     except Exception:
         # TODO: ensure we are in the "correct" state (i.e. no policy but metadata exists)
         error(
-            "Failed to delete project metadata retention ID. Retention policy will be restored."
+            "Failed to delete project metadata retention ID. Retention policy will be restored.",
+            exc_info=True,
         )
         state.run(
             state.client.create_retention_policy(policy),
             "Restoring retention policy...",
         )
 
-    logger.info(f"Deleted retention policy {policy_id}.")
+    info(f"Deleted retention policy {policy_id}.")
 
 
 # HarborAsyncClient.get_retention_policy_id()
@@ -235,7 +236,7 @@ def start_retention_job(
     msg = f"Started retention job at {location}."
     if dry_run:
         msg += " (Dry run)"
-    logger.info(msg)
+    info(msg)
 
 
 # HarborAsyncClient.stop_retention_execution()
@@ -253,7 +254,7 @@ def stop_retention_job(
         state.client.stop_retention_execution(policy_id, job_id),
         "Stopping retention job...",
     )
-    logger.info(f"Stopped retention job ({job_id}) for policy {policy_id}.")
+    info(f"Stopped retention job ({job_id}) for policy {policy_id}.")
 
 
 # HarborAsyncClient.get_retention_tasks()

--- a/harbor_cli/commands/api/scan.py
+++ b/harbor_cli/commands/api/scan.py
@@ -8,7 +8,7 @@ import typer
 from harborapi.models import ScanDataExportRequest
 
 from ...harbor.artifact import parse_artifact_name
-from ...logs import logger
+from ...output.console import info
 from ...output.render import render_result
 from ...state import get_state
 from ...style import render_cli_value
@@ -48,7 +48,7 @@ def start_scan(
         state.client.scan_artifact(an.project, an.repository, an.reference),
         "Starting artifact scan...",
     )
-    logger.info(f"Scan of {artifact!r} started.")
+    info(f"Scan of {artifact!r} started.")
     # TODO: add some sort of results?
 
 
@@ -67,7 +67,7 @@ def stop_scan(
         state.client.stop_artifact_scan(an.project, an.repository, an.reference),
         "Stopping artifact scan...",
     )
-    logger.info(f"Scan of {artifact!r} stopped.")
+    info(f"Scan of {artifact!r} stopped.")
 
 
 # HarborAsyncClient.stop_scan_all_job()
@@ -232,4 +232,4 @@ def download_scan_export(
     # TODO: check resp code + handle errors
     with destination.open("wb") as f:
         f.write(bytes(export))
-    logger.info(f"Export downloaded to {destination!s}")
+    info(f"Export downloaded to {destination!s}")

--- a/harbor_cli/commands/api/scanall.py
+++ b/harbor_cli/commands/api/scanall.py
@@ -6,8 +6,8 @@ import typer
 from harborapi.models import Schedule
 from harborapi.models import ScheduleObj
 
-from ...logs import logger
 from ...output.console import exit_err
+from ...output.console import info
 from ...output.render import render_result
 from ...state import get_state
 from ...utils.args import create_updated_model
@@ -68,7 +68,7 @@ def create_scanall_schedule(
         state.client.create_scan_all_schedule(schedule),
         "Creating 'Scan All' schedule...",
     )
-    logger.info(f"'Scan All' schedule created.")
+    info(f"'Scan All' schedule created.")
 
 
 @schedule_cmd.command("update")
@@ -89,7 +89,7 @@ def update_scanall_schedule(
         state.client.update_scan_all_schedule(schedule),
         "Updating 'Scan All' schedule...",
     )
-    logger.info(f"'Scan All' schedule created.")
+    info(f"'Scan All' schedule created.")
 
 
 # HarborAsyncClient.stop_scan_all_job()
@@ -97,4 +97,4 @@ def update_scanall_schedule(
 def stop_scanall_job(ctx: typer.Context) -> None:
     """Stop the currently running 'Scan All' job."""
     state.run(state.client.stop_scan_all_job(), "Stopping 'Scan All' job...")
-    logger.info(f"'Scan All' job stopped.")
+    info(f"'Scan All' job stopped.")

--- a/harbor_cli/commands/api/scanner.py
+++ b/harbor_cli/commands/api/scanner.py
@@ -6,7 +6,7 @@ import typer
 from harborapi.models.models import ScannerRegistration
 from harborapi.models.models import ScannerRegistrationReq
 
-from ...logs import logger
+from ...output.console import info
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
 from ...state import get_state
@@ -88,7 +88,7 @@ def create_scanner(
     req = ScannerRegistrationReq(**params)
     location = state.run(state.client.create_scanner(req), "Creating scanner...")
     render_result(location, ctx)
-    logger.info(f"Scanner created: {location}.")
+    info(f"Scanner created: {location}.")
 
 
 # HarborAsyncClient.update_scanner()
@@ -141,7 +141,7 @@ def update_scanner(
         state.client.update_scanner(scanner_id, req),
         "Updating scanner...",
     )
-    logger.info(f"Scanner {scanner_id!r} updated.")
+    info(f"Scanner {scanner_id!r} updated.")
 
 
 # HarborAsyncClient.delete_scanner()
@@ -157,7 +157,7 @@ def delete_scanner(
     """Delete a scanner."""
     delete_prompt(state.config, force, resource="scanner", name=str(scanner_id))
     state.run(state.client.delete_scanner(scanner_id), "Deleting scanner...")
-    logger.info(f"Scanner with ID {scanner_id!r} deleted.")
+    info(f"Scanner with ID {scanner_id!r} deleted.")
 
 
 # HarborAsyncClient.get_scanners()
@@ -205,7 +205,7 @@ def set_default_scanner(
         state.client.set_default_scanner(scanner_id, is_default),
         "Setting default scanner...",
     )
-    logger.info(f"Scanner with ID {scanner_id!r} set as default.")
+    info(f"Scanner with ID {scanner_id!r} set as default.")
 
 
 # HarborAsyncClient.ping_scanner_adapter()

--- a/harbor_cli/commands/api/user.py
+++ b/harbor_cli/commands/api/user.py
@@ -10,7 +10,7 @@ from harborapi.models.models import UserProfile
 from harborapi.models.models import UserResp
 
 from ...exceptions import HarborCLIError
-from ...logs import logger
+from ...output.console import info
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
 from ...state import get_state
@@ -186,7 +186,7 @@ def create_user(
     )
     user_info = state.run(state.client.create_user(req), f"Creating user...")
     render_result(user_info, ctx)
-    logger.info(f"Created user {username!r}.")
+    info(f"Created user {username!r}.")
 
 
 # HarborAsyncClient.update_user()
@@ -215,7 +215,7 @@ def update_user(
         )
     req = create_updated_model(user, UserProfile, ctx)
     state.run(state.client.update_user(user.user_id, req), "Updating user...")
-    logger.info(f"Updated user.")
+    info(f"Updated user.")
 
 
 # HarborAsyncClient.delete_user()
@@ -228,7 +228,7 @@ def delete_user(
     delete_prompt(state.config, force, resource="user", name=username_or_id)
     uid = uid_from_username_or_id(username_or_id)
     state.run(state.client.delete_user(uid), "Deleting user...")
-    logger.info(f"Deleted user with ID {uid}.")
+    info(f"Deleted user with ID {uid}.")
 
 
 # HarborAsyncClient.search_users_by_username()
@@ -268,7 +268,7 @@ def set_user_admin(
     state.run(
         state.client.set_user_admin(uid, is_admin=True), "Setting user as admin..."
     )
-    logger.info(f"Set user with ID {uid} as admin.")
+    info(f"Set user with ID {uid} as admin.")
 
 
 @app.command("unset-admin")
@@ -281,7 +281,7 @@ def unset_user_admin(
     state.run(
         state.client.set_user_admin(uid, is_admin=False), "Removing user as admin..."
     )
-    logger.info(f"Removed user with ID {uid} as admin.")
+    info(f"Removed user with ID {uid} as admin.")
 
 
 # HarborAsyncClient.set_user_password()
@@ -316,7 +316,7 @@ def set_user_password(
         ),
         "Setting password for user...",
     )
-    logger.info(f"Set password for user with ID {uid}.")
+    info(f"Set password for user with ID {uid}.")
 
 
 # HarborAsyncClient.set_user_cli_secret()
@@ -336,7 +336,7 @@ def set_user_cli_secret(
     state.run(
         state.client.set_user_cli_secret(uid, secret), "Setting CLI secret for user..."
     )
-    logger.info(f"Set CLI secret for user with ID {uid}.")
+    info(f"Set CLI secret for user with ID {uid}.")
 
 
 # HarborAsyncClient.get_current_user()
@@ -408,10 +408,8 @@ def list_users(
     users = state.run(
         state.client.get_users(
             query=query,
-            # we do the sorting ourselves later
             page=page,
             page_size=page_size,
-            # we do the limiting ourselves later
         ),
         "Fetching users...",
     )

--- a/harbor_cli/commands/api/usergroup.py
+++ b/harbor_cli/commands/api/usergroup.py
@@ -5,9 +5,9 @@ from typing import Optional
 import typer
 from harborapi.models.models import UserGroup
 
-from ...logs import logger
 from ...models import UserGroupType
 from ...output.console import exit_err
+from ...output.console import info
 from ...output.prompts import delete_prompt
 from ...output.render import render_result
 from ...state import get_state
@@ -83,7 +83,7 @@ def update_usergroup(
         state.client.update_usergroup(group_id, usergroup),
         f"Updating user group {group_id}...",
     )
-    logger.info(f"Updated user group {group_id}.")
+    info(f"Updated user group {group_id}.")
 
 
 # HarborAsyncClient.delete_usergroup()
@@ -98,7 +98,7 @@ def delete_usergroup(
     state.run(
         state.client.delete_usergroup(group_id), f"Deleting user group {group_id}..."
     )
-    logger.info(f"Deleted user group {group_id}.")
+    info(f"Deleted user group {group_id}.")
 
 
 # HarborAsyncClient.get_usergroups()

--- a/harbor_cli/commands/cli/cache.py
+++ b/harbor_cli/commands/cli/cache.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 from rich.table import Table
 
 from ...cache import Cache
-from ...output.console import console
 from ...output.console import info
 from ...output.render import render_result
 from ...output.table._utils import get_table
@@ -106,4 +105,4 @@ def cache_info(ctx: typer.Context) -> None:
 def cache_clear(ctx: typer.Context) -> None:
     """Clear the CLI's internal cache."""
     state.cache.clear()
-    console.print("Cache cleared.")
+    info("Cache cleared.")

--- a/harbor_cli/commands/cli/cli_config.py
+++ b/harbor_cli/commands/cli/cli_config.py
@@ -16,6 +16,7 @@ from ...config import EnvVar
 from ...config import HarborCLIConfig
 from ...models import BaseModel
 from ...output.console import console
+from ...output.console import error
 from ...output.console import exit
 from ...output.console import exit_err
 from ...output.console import info
@@ -218,6 +219,16 @@ def write_session_config(
 )
 def show_config_path(ctx: typer.Context) -> None:
     path = state.config.config_file or DEFAULT_CONFIG_FILE
+    if not path.exists():
+        info("File does not exist.")
+    elif path.is_dir():
+        # this branch should be unreachable since HarborCLIConfig.from_file()
+        # should fail if the path is a directory
+        error(
+            "Path is a directory. Delete the directory so a config file can be created."
+        )
+    elif not path.read_text().strip():
+        info("File exists, but is empty.")
     render_result(path, ctx)
 
 

--- a/harbor_cli/commands/cli/find.py
+++ b/harbor_cli/commands/cli/find.py
@@ -9,8 +9,8 @@ import typer
 from fuzzywuzzy import fuzz
 
 from ...app import app
-from ...logs import logger
 from ...models import CommandSummary
+from ...output.console import warning
 from ...output.render import render_result
 from ...utils.commands import get_app_commands
 
@@ -140,7 +140,7 @@ def _do_find(
         strategy=strategy,
     )
     if limit is not None and len(matches) > limit:
-        logger.warning(f"{len(matches) - limit} results omitted.")
+        warning(f"{len(matches) - limit} results omitted.")
         matches = matches[:limit]
     return matches
 

--- a/harbor_cli/commands/cli/init.py
+++ b/harbor_cli/commands/cli/init.py
@@ -148,8 +148,8 @@ def run_config_wizard(config_path: Optional[Path] = None) -> HarborCLIConfig:
     if not conf_path:
         raise ConfigError("Could not determine config file path.")
     save_config(config, conf_path)
-    console.print("Configuration complete! :tada:")
-    success(f"Saved config to {path_link(conf_path)}")
+    success("Configuration complete! :tada:")
+    info(f"Saved config to {path_link(conf_path)}")
     return config
 
 

--- a/harbor_cli/commands/cli/init.py
+++ b/harbor_cli/commands/cli/init.py
@@ -19,12 +19,11 @@ from ...format import OutputFormat
 from ...harbor.common import prompt_basicauth
 from ...harbor.common import prompt_credentials_file
 from ...harbor.common import prompt_username_secret
-from ...logs import logger
 from ...logs import LogLevel
 from ...output.console import console
 from ...output.console import error
-from ...output.console import exit
 from ...output.console import exit_err
+from ...output.console import info
 from ...output.console import success
 from ...output.console import warning
 from ...output.formatting import path_link
@@ -34,7 +33,7 @@ from ...output.prompts import path_prompt
 from ...output.prompts import str_prompt
 from ...state import get_state
 from ...style import render_cli_option
-from ...style import STYLE_COMMAND
+from ...style.style import render_cli_command
 from ...utils.keyring import keyring_supported
 from ...utils.keyring import set_password
 
@@ -79,7 +78,7 @@ def init(
             exit_err(msg)
         config_path = None
     else:
-        logger.info(f"Created config file at {config_path}")
+        info(f"Created config file at {config_path}")
 
     config = run_config_wizard(config_path)
     state.config = config
@@ -99,11 +98,10 @@ def run_config_wizard(config_path: Optional[Path] = None) -> HarborCLIConfig:
     try:
         config = HarborCLIConfig.from_file(config_path)
     except Exception as e:
-        error(f"Failed to load config: {e}")
-        error(
-            f"[white]Run [{STYLE_COMMAND}]harbor init --overwrite[/] to create a new config file.[/]"
+        exit_err(
+            f"Failed to load config: {e}. Run {render_cli_command('harbor init --overwrite')} to create a new config file.",
+            exc_info=True,
         )
-        exit(code=1)
 
     assert config.config_file is not None
 
@@ -353,7 +351,7 @@ def _init_output_format(config: HarborCLIConfig) -> None:
         elif fmt == OutputFormat.TABLE:
             _init_output_table_settings(config)
         else:
-            logger.error(f"Unknown configuration format {fmt.value}")
+            error(f"Unknown configuration format {fmt.value}")
 
     # Configure the chosen format first
     conf_fmt(oconf.format)

--- a/harbor_cli/commands/cli/init.py
+++ b/harbor_cli/commands/cli/init.py
@@ -35,7 +35,7 @@ from ...output.prompts import str_prompt
 from ...state import get_state
 from ...style import render_cli_option
 from ...style import STYLE_COMMAND
-from ...utils.keyring import KEYRING_SUPPORTED
+from ...utils.keyring import keyring_supported
 from ...utils.keyring import set_password
 
 state = get_state()
@@ -199,7 +199,7 @@ def init_harbor_settings(config: HarborCLIConfig) -> None:
 
 def set_username_secret(hconf: HarborSettings, current_username: str) -> None:
     username, secret = prompt_username_secret(current_username, hconf.secret_value)
-    if KEYRING_SUPPORTED:
+    if keyring_supported():
         _set_username_secret_keyring(hconf, username, secret)
     else:
         _set_username_secret_config(hconf, username, secret)
@@ -315,8 +315,6 @@ def init_output_settings(config: HarborCLIConfig) -> None:
 
     oconf = config.output
 
-    # Output format configuration has numerous sub-options,
-    # so we delegate to a separate function.
     _init_output_format(config)
 
     # Leading newline to separate from format configuration(s)
@@ -340,6 +338,7 @@ def init_output_settings(config: HarborCLIConfig) -> None:
 
 
 def _init_output_format(config: HarborCLIConfig) -> None:
+    """Initialize output format settings."""
     oconf = config.output
     fmt_in = str_prompt(
         "Default output format",

--- a/harbor_cli/config.py
+++ b/harbor_cli/config.py
@@ -260,7 +260,6 @@ class HarborSettings(BaseModel):
 
 class LoggingSettings(BaseModel):
     enabled: bool = True
-    structlog: bool = False
     level: LogLevel = LogLevel.WARNING
     directory: Path = LOGS_DIR
     filename: str = "harbor_cli-{time}.log"

--- a/harbor_cli/config.py
+++ b/harbor_cli/config.py
@@ -77,6 +77,7 @@ class EnvVar(StrEnum):
     PAGER = env_var("pager")
     CONFIRM_DELETION = env_var("confirm_deletion")
     CONFIRM_ENUMERATION = env_var("confirm_enumeration")
+    WARNINGS = env_var("warnings")
     CACHE_ENABLED = env_var("cache_enabled")
     CACHE_TTL = env_var("cache_ttl")
 
@@ -437,6 +438,10 @@ class GeneralSettings(BaseModel):
             "Show confirmation prompt for certain resource enumeration "
             "commands when invoked without a limit or filter. E.g. `auditlog list`"
         ),
+    )
+    warnings: bool = Field(
+        True,
+        description="Show warning messages in terminal. Warnings are always logged regardless of this option.",
     )
 
 

--- a/harbor_cli/deprecation.py
+++ b/harbor_cli/deprecation.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import typer
 
-from .logs import logger
+from .output.console import warning
 
 
 class Deprecated(str):
@@ -86,4 +86,4 @@ def check_deprecated_options(ctx: typer.Context) -> None:
             msg = f"Option {param} is deprecated."
             if param.replacement:
                 msg += f" Use {param.replacement} instead."
-            logger.warning(msg)
+            warning(msg)

--- a/harbor_cli/dirs.py
+++ b/harbor_cli/dirs.py
@@ -4,7 +4,6 @@ from platformdirs import PlatformDirs
 
 from .__about__ import APP_NAME
 from .__about__ import AUTHOR
-from .exceptions import DirectoryCreateError
 from .logs import logger
 
 _PLATFORM_DIR = PlatformDirs(APP_NAME, AUTHOR)
@@ -24,4 +23,7 @@ def init_directories() -> None:
                 f"Unable to create directory {directory}: {e}",
                 exc_info=True,
             )
-            raise DirectoryCreateError(f"Unable to create directory {directory}") from e
+            continue
+
+
+init_directories()

--- a/harbor_cli/dirs.py
+++ b/harbor_cli/dirs.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from loguru import logger
 from platformdirs import PlatformDirs
 
 from .__about__ import APP_NAME
 from .__about__ import AUTHOR
 from .exceptions import DirectoryCreateError
+from .logs import logger
 
 _PLATFORM_DIR = PlatformDirs(APP_NAME, AUTHOR)
 CONFIG_DIR = _PLATFORM_DIR.user_config_path
@@ -20,7 +20,8 @@ def init_directories() -> None:
             directory.mkdir(parents=True, exist_ok=True)
         except Exception as e:
             # TODO: deduplicate these messages
-            logger.bind(exception=e).error(
-                f"Unable to create directory {directory}: {e}"
+            logger.error(
+                f"Unable to create directory {directory}: {e}",
+                exc_info=True,
             )
             raise DirectoryCreateError(f"Unable to create directory {directory}") from e

--- a/harbor_cli/dirs.py
+++ b/harbor_cli/dirs.py
@@ -4,7 +4,7 @@ from platformdirs import PlatformDirs
 
 from .__about__ import APP_NAME
 from .__about__ import AUTHOR
-from .logs import logger
+
 
 _PLATFORM_DIR = PlatformDirs(APP_NAME, AUTHOR)
 CONFIG_DIR = _PLATFORM_DIR.user_config_path
@@ -18,8 +18,10 @@ def init_directories() -> None:
         try:
             directory.mkdir(parents=True, exist_ok=True)
         except Exception as e:
+            from .output.console import error
+
             # TODO: deduplicate these messages
-            logger.error(
+            error(
                 f"Unable to create directory {directory}: {e}",
                 exc_info=True,
             )

--- a/harbor_cli/format.py
+++ b/harbor_cli/format.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from .logs import logger
+from .output.console import warning
 
 
 class OutputFormat(Enum):
@@ -35,7 +35,7 @@ def output_format_repr(fmt: OutputFormat) -> str:
     """Return a human-readable representation of an output format."""
     f = OUTPUTFORMAT_REPR.get(fmt)
     if f is None:
-        logger.warning(f"Unknown output format: {fmt}")
+        warning(f"Unknown output format: {fmt}")
         f = "Unknown"
     return f
 
@@ -44,6 +44,6 @@ def output_format_emoji(fmt: OutputFormat) -> str:
     """Return an emoji for an output format."""
     f = OUTPUTFORMAT_EMOJI.get(fmt)
     if f is None:
-        logger.warning(f"Unknown output format: {fmt}")
+        warning(f"Unknown output format: {fmt}")
         f = ":question:"
     return f

--- a/harbor_cli/logs.py
+++ b/harbor_cli/logs.py
@@ -90,9 +90,7 @@ def setup_logging(config: LoggingSettings) -> None:
 
     # Create file handler for detailed logs
     file_handler = logging.FileHandler(config.path)
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 

--- a/harbor_cli/logs.py
+++ b/harbor_cli/logs.py
@@ -9,19 +9,11 @@ if TYPE_CHECKING:
 
 
 import logging
-from rich.logging import RichHandler
 
 
 # Create logger
 logger = logging.getLogger("harbor-cli")
 logger.setLevel(logging.DEBUG)  # Capture all log messages
-
-
-# Create stderr handler for user-friendly messages
-stderr_handler = RichHandler(
-    level=logging.INFO, show_time=False, show_path=False, markup=True
-)
-logger.addHandler(stderr_handler)
 
 
 class LogLevel(Enum):
@@ -82,15 +74,14 @@ _LOGGING_INIT = False
 def setup_logging(config: LoggingSettings) -> None:
     """Set up stderr logging."""
     global _LOGGING_INIT
-    if _LOGGING_INIT:
+    if _LOGGING_INIT:  # prevent re-configuring in REPL
         return
-
-    # stderr logger
-    stderr_handler.setLevel(config.level.as_int())
 
     # Create file handler for detailed logs
     file_handler = logging.FileHandler(config.path)
-    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] [%(module)s:%(filename)s:%(lineno)s - %(funcName)s()] %(message)s"
+    )
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 

--- a/harbor_cli/logs.py
+++ b/harbor_cli/logs.py
@@ -56,18 +56,6 @@ class LogLevel(Enum):
         return res
 
 
-COLOR_DEFAULT = "white"
-COLORS = {
-    "TRACE": "white",
-    "DEBUG": "white",
-    "INFO": "white",
-    "SUCCESS": "white",
-    "WARNING": "yellow",
-    "ERROR": "red",
-    "CRITICAL": "red",
-}
-
-
 _LOGGING_INIT = False
 
 

--- a/harbor_cli/main.py
+++ b/harbor_cli/main.py
@@ -259,6 +259,13 @@ def main_callback(
         envvar=EnvVar.CONFIRM_ENUMERATION,
         config_override="general.confirm_enumeration",
     ),
+    warnings: Optional[bool] = Option(
+        None,
+        "--warnings/--no-warnings",
+        help="Show/hide warnings.",
+        envvar=EnvVar.WARNINGS,
+        config_override="general.warnings",
+    ),
     # Cache options
     cache_enabled: Optional[bool] = Option(
         None,
@@ -380,6 +387,8 @@ def main_callback(
         state.config.general.confirm_enumeration = confirm_enumeration
     if confirm_deletion is not None:
         state.config.general.confirm_deletion = confirm_deletion
+    if warnings is not None:
+        state.config.general.warnings = warnings
     # Cache
     if cache_enabled is not None:
         state.config.cache.enabled = cache_enabled

--- a/harbor_cli/main.py
+++ b/harbor_cli/main.py
@@ -16,12 +16,14 @@ from .config import EnvVar
 from .config import HarborCLIConfig
 from .deprecation import check_deprecated_options
 from .deprecation import Deprecated
+from .exceptions import ConfigError
 from .exceptions import handle_exception
 from .exceptions import HarborCLIError
 from .format import OutputFormat
 from .logs import disable_logging
 from .logs import setup_logging
 from .option import Option
+from .output.console import error
 from .output.console import exit
 from .output.console import exit_err
 from .output.console import info
@@ -421,7 +423,7 @@ def try_load_config(config_file: Optional[Path], create: bool = True) -> None:
         try:
             conf = HarborCLIConfig.from_file(config_file)
         except FileNotFoundError:
-            if not create:  # TODO: handle ConfigError
+            if not create:
                 return
             # Create a new config file and run wizard
             info("Config file not found. Creating new config file.")
@@ -431,6 +433,9 @@ def try_load_config(config_file: Optional[Path], create: bool = True) -> None:
             info(f"Created config file: {path_link(conf.config_file)}")
             info("Running configuration wizard...")
             conf = run_config_wizard(conf.config_file)
+        except ConfigError as e:
+            error(f"Unable to load config: {str(e)}", exc_info=True)
+            return
 
         state.config = conf
 

--- a/harbor_cli/models.py
+++ b/harbor_cli/models.py
@@ -19,6 +19,7 @@ from harborapi.models import VulnerabilitySummary
 from harborapi.models.base import BaseModel as HarborAPIBaseModel
 from pydantic import Field
 from pydantic import root_validator
+from strenum import StrEnum
 from typer.core import TyperArgument
 from typer.core import TyperCommand
 
@@ -229,17 +230,17 @@ class Operator(Enum):
 
 # We use this enum to provide choices in the CLI, but we also use it to determine
 # the integer value of the group type when we need to send it to the API.
-class UserGroupType(str, Enum):
+class UserGroupType(StrEnum):
     LDAP = "LDAP"
     HTTP = "HTTP"
     OIDC = "OIDC"
 
     @classmethod
-    def from_int(cls, value: int) -> UserGroupType:
+    def from_int(cls, value: int) -> str:
         try:
             return _USERGROUPTYPE_MAPPING[value]
         except KeyError:
-            raise ValueError(f"Unknown user group type: {value}")
+            raise ValueError(f"Invalid user group type: {value}")
 
     def as_int(self) -> int:
         try:
@@ -248,16 +249,20 @@ class UserGroupType(str, Enum):
             raise ValueError(f"Unknown user group type: {self}")
 
 
+# NOTE: Dict keys are typed as str instead of UserGroupType
+# https://github.com/python/mypy/issues/14688
+
+
 # NOTE: could replace with a bidict or similar
 _USERGROUPTYPE_MAPPING = {
     1: UserGroupType.LDAP,
     2: UserGroupType.HTTP,
     3: UserGroupType.OIDC,
-}  # type: dict[int, UserGroupType]
+}  # type: dict[int, str]
 
 _USERGROUPTYPE_MAPPING_REVERSE = {
     v: k for k, v in _USERGROUPTYPE_MAPPING.items()
-}  # type: dict[UserGroupType, int]
+}  # type: dict[str, int]
 
 
 # We use this enum to provide choices in the CLI, but we also use it to determine

--- a/harbor_cli/output/console.py
+++ b/harbor_cli/output/console.py
@@ -6,7 +6,9 @@ from typing import Optional
 
 from rich.console import Console
 
+from ..logs import logger
 from ..style import Icon
+from ..style.color import bold
 from ..style.color import green
 from ..style.color import red
 from ..style.color import yellow
@@ -35,12 +37,14 @@ def success(message: str, icon: str = Icon.OK, **kwargs) -> None:
 
 
 def warning(message: str, icon: str = Icon.WARNING, **kwargs) -> None:
-    # logger.warning(message, extra=dict(**kwargs))
-    err_console.print(f"{yellow(icon)} {message}")
+    logger.warning(message, extra=dict(**kwargs))
+    err_console.print(bold(f"{yellow(icon)} {message}"))
 
 
-def error(message: str, icon: str = Icon.ERROR, **kwargs) -> None:
-    # logger.error(message, extra=dict(**kwargs))
+def error(
+    message: str, icon: str = Icon.ERROR, exc_info: bool = False, **kwargs
+) -> None:
+    logger.error(message, extra=dict(**kwargs), exc_info=exc_info)
     err_console.print(f"{red(icon)} {message}")
 
 

--- a/harbor_cli/output/console.py
+++ b/harbor_cli/output/console.py
@@ -28,12 +28,14 @@ err_console = Console(
 
 
 def info(message: str, icon: str = Icon.INFO, *args, **kwargs) -> None:
-    # logger.info(message, extra=dict(**kwargs))
+    """Log with INFO level and print an informational message."""
+    logger.info(message, extra=dict(**kwargs))
     err_console.print(f"{green(icon)} {message}")
 
 
 def success(message: str, icon: str = Icon.OK, **kwargs) -> None:
-    # logger.info(message, extra=dict(**kwargs))
+    """Log with DEBUG level and print a success message."""
+    logger.debug(message, extra=dict(**kwargs))
     err_console.print(f"{green(icon)} {message}")
 
 
@@ -47,6 +49,7 @@ def warning(message: str, icon: str = Icon.WARNING, **kwargs) -> None:
 def error(
     message: str, icon: str = Icon.ERROR, exc_info: bool = False, **kwargs
 ) -> None:
+    """Log with ERROR level and print an error message."""
     logger.error(message, extra=dict(**kwargs), exc_info=exc_info)
     err_console.print(f"{red(icon)} {message}")
 

--- a/harbor_cli/output/console.py
+++ b/harbor_cli/output/console.py
@@ -19,28 +19,23 @@ err_console = Console(
 
 
 def info(message: str, *args, **kwargs) -> None:
-    """Prints an unstyled message to the stderr console."""
-    logger.info(message)
+    logger.info(message, extra=dict(**kwargs))
 
 
 def success(message: str, *args, **kwargs) -> None:
-    """Prints a green message to the stderr console."""
-    logger.info(message)
+    logger.info(message, extra=dict(**kwargs))
 
 
 def warning(message: str, *args, **kwargs) -> None:
-    """Prints a yellow message with a warning prefix to the stderr console."""
-    logger.warning(message)
+    logger.warning(message, extra=dict(**kwargs))
 
 
 def error(message: str, *args, **kwargs) -> None:
-    """Prints a red message with an error prefix to the stderr console."""
-    logger.error(message)
+    logger.error(message, extra=dict(**kwargs))
 
 
-def exit(message: Optional[str] = None, code: int = 0) -> NoReturn:
-    """Prints a message to the default console and exits with the given
-    code (default: 0).
+def exit(message: Optional[str] = None, code: int = 0, **kwargs) -> NoReturn:
+    """Logs a message with INFO level and exits with the given code (default: 0)
 
     Parameters
     ----------
@@ -48,14 +43,16 @@ def exit(message: Optional[str] = None, code: int = 0) -> NoReturn:
         Message to print.
     code : int, optional
         Exit code, by default 0
+    **kwargs
+        Additional keyword arguments to pass to the extra dict.
     """
     if message:
-        logger.info(message)
+        info(message, **kwargs)
     raise SystemExit(code)
 
 
-def exit_err(message: str, code: int = 1, **extra: Any) -> NoReturn:
-    """Prints a message to the error console and exits with the given
+def exit_err(message: str, code: int = 1, **kwargs: Any) -> NoReturn:
+    """Logs a message with ERROR level and exits with the given
     code (default: 1).
 
     Parameters
@@ -64,6 +61,8 @@ def exit_err(message: str, code: int = 1, **extra: Any) -> NoReturn:
         Message to print.
     code : int, optional
         Exit code, by default 1
+    **kwargs
+        Additional keyword arguments to pass to the extra dict.
     """
-    logger.error(message, extra=dict(**extra))
+    error(message, **kwargs)
     raise SystemExit(code)

--- a/harbor_cli/output/console.py
+++ b/harbor_cli/output/console.py
@@ -6,11 +6,17 @@ from typing import Optional
 
 from rich.console import Console
 
-from ..logs import logger
+from ..style import Icon
+from ..style.color import green
+from ..style.color import red
+from ..style.color import yellow
 
 _exit = exit  # save the original exit function
 
+# stdout console used to print results
 console = Console()
+
+# stderr console used to print prompts, messages, etc.
 err_console = Console(
     stderr=True,
     highlight=False,
@@ -18,20 +24,24 @@ err_console = Console(
 )
 
 
-def info(message: str, *args, **kwargs) -> None:
-    logger.info(message, extra=dict(**kwargs))
+def info(message: str, icon: str = Icon.INFO, *args, **kwargs) -> None:
+    # logger.info(message, extra=dict(**kwargs))
+    err_console.print(f"{green(icon)} {message}")
 
 
-def success(message: str, *args, **kwargs) -> None:
-    logger.info(message, extra=dict(**kwargs))
+def success(message: str, icon: str = Icon.OK, **kwargs) -> None:
+    # logger.info(message, extra=dict(**kwargs))
+    err_console.print(f"{green(icon)} {message}")
 
 
-def warning(message: str, *args, **kwargs) -> None:
-    logger.warning(message, extra=dict(**kwargs))
+def warning(message: str, icon: str = Icon.WARNING, **kwargs) -> None:
+    # logger.warning(message, extra=dict(**kwargs))
+    err_console.print(f"{yellow(icon)} {message}")
 
 
-def error(message: str, *args, **kwargs) -> None:
-    logger.error(message, extra=dict(**kwargs))
+def error(message: str, icon: str = Icon.ERROR, **kwargs) -> None:
+    # logger.error(message, extra=dict(**kwargs))
+    err_console.print(f"{red(icon)} {message}")
 
 
 def exit(message: Optional[str] = None, code: int = 0, **kwargs) -> NoReturn:

--- a/harbor_cli/output/console.py
+++ b/harbor_cli/output/console.py
@@ -7,6 +7,7 @@ from typing import Optional
 from rich.console import Console
 
 from ..logs import logger
+from ..state import get_state
 from ..style import Icon
 from ..style.color import bold
 from ..style.color import green
@@ -37,8 +38,10 @@ def success(message: str, icon: str = Icon.OK, **kwargs) -> None:
 
 
 def warning(message: str, icon: str = Icon.WARNING, **kwargs) -> None:
+    """Log with WARNING level and optionally print a warning message."""
     logger.warning(message, extra=dict(**kwargs))
-    err_console.print(bold(f"{yellow(icon)} {message}"))
+    if get_state().config.general.warnings:
+        err_console.print(bold(f"{yellow(icon)} {message}"))
 
 
 def error(

--- a/harbor_cli/output/console.py
+++ b/harbor_cli/output/console.py
@@ -4,8 +4,9 @@ from typing import Any
 from typing import NoReturn
 from typing import Optional
 
-from rich import markup
 from rich.console import Console
+
+from ..logs import logger
 
 _exit = exit  # save the original exit function
 
@@ -17,40 +18,24 @@ err_console = Console(
 )
 
 
-def _add_fix(message: str, prefix: str | None, suffix: str | None = None) -> str:
-    if prefix:
-        prefix = f"[bold]\[{markup.escape(prefix.strip())}][/]"
-        message = f"{prefix} {message}"
-    if suffix:
-        suffix = suffix.strip()
-        message = f"{message} {suffix}"
-    return message
-
-
-def info(message: str, prefix: str | None = None, suffix: str | None = None) -> None:
+def info(message: str, *args, **kwargs) -> None:
     """Prints an unstyled message to the stderr console."""
-    message = _add_fix(message, prefix, suffix)
-    err_console.print(message)
+    logger.info(message)
 
 
-def success(
-    message: str, prefix: str | None = None, suffix: str | None = ":white_check_mark:"
-) -> None:
+def success(message: str, *args, **kwargs) -> None:
     """Prints a green message to the stderr console."""
-    message = _add_fix(message, prefix, suffix)
-    err_console.print(message, style="green")
+    logger.info(message)
 
 
-def warning(message: str, prefix: str = "WARNING", suffix: str | None = None) -> None:
+def warning(message: str, *args, **kwargs) -> None:
     """Prints a yellow message with a warning prefix to the stderr console."""
-    message = _add_fix(message, prefix, suffix)
-    err_console.print(message, style="yellow")
+    logger.warning(message)
 
 
-def error(message: str, prefix: str = "ERROR", suffix: str | None = None) -> None:
+def error(message: str, *args, **kwargs) -> None:
     """Prints a red message with an error prefix to the stderr console."""
-    message = _add_fix(message, prefix, suffix)
-    err_console.print(message, style="red")
+    logger.error(message)
 
 
 def exit(message: Optional[str] = None, code: int = 0) -> NoReturn:
@@ -65,7 +50,7 @@ def exit(message: Optional[str] = None, code: int = 0) -> NoReturn:
         Exit code, by default 0
     """
     if message:
-        info(message)
+        logger.info(message)
     raise SystemExit(code)
 
 
@@ -80,5 +65,5 @@ def exit_err(message: str, code: int = 1, **extra: Any) -> NoReturn:
     code : int, optional
         Exit code, by default 1
     """
-    error(message)
+    logger.error(message, extra=dict(**extra))
     raise SystemExit(code)

--- a/harbor_cli/output/console.py
+++ b/harbor_cli/output/console.py
@@ -51,7 +51,7 @@ def error(
 ) -> None:
     """Log with ERROR level and print an error message."""
     logger.error(message, extra=dict(**kwargs), exc_info=exc_info)
-    err_console.print(f"{red(icon)} {message}")
+    err_console.print(bold(f"{red(icon)} {message}"))
 
 
 def exit(message: Optional[str] = None, code: int = 0, **kwargs) -> NoReturn:

--- a/harbor_cli/output/prompts.py
+++ b/harbor_cli/output/prompts.py
@@ -30,7 +30,7 @@ from .formatting.path import path_link
 
 
 def prompt_msg(*msgs: str) -> str:
-    return f"[bold]{green(Icon.PROMPT)} {' '.join(msg.strip() for msg in msgs)}[/bold]"
+    return f"[bold]{green(Icon.PROMPT)} {' '.join(msg.strip() for msg in filter(None, msgs))}[/bold]"
 
 
 def str_prompt(

--- a/harbor_cli/output/prompts.py
+++ b/harbor_cli/output/prompts.py
@@ -22,7 +22,14 @@ from ..style import STYLE_CLI_OPTION, render_warning
 from .console import console
 from .console import error
 from .console import exit
+from ..style.color import yellow
+from ..style.color import green
+from ..style import Icon
 from .formatting.path import path_link
+
+
+def prompt_msg(*msgs: str) -> str:
+    return f"[bold]{green(Icon.PROMPT)} {' '.join(msgs)}[/bold]"
 
 
 def str_prompt(
@@ -60,15 +67,15 @@ def str_prompt(
     # Notify user that a default secret will be used,
     # but don't actually show the secret
     if password and default not in (None, ..., ""):
-        _add_str = " (leave empty to use existing value)"
+        _prompt_add = " (leave empty to use existing value)"
     else:
-        _add_str = ""
+        _prompt_add = ""
+    msg = prompt_msg(prompt, _prompt_add)
 
     inp = None
-
     while not inp:
         inp = Prompt.ask(
-            f"{prompt}{_add_str}",
+            msg,
             console=console,
             password=password,
             show_default=show_default,
@@ -173,8 +180,8 @@ def _number_prompt(
 ) -> int | float:
     default_arg = ... if default is None else default
 
+    _prompt_add = ""
     if show_range:
-        _prompt_add = ""
         if min is not None and max is not None:
             if min > max:
                 raise ValueError("min must be less than or equal to max")
@@ -184,11 +191,12 @@ def _number_prompt(
         elif max is not None:
             _prompt_add = f"x<={max}"
         if _prompt_add:
-            prompt = f"{prompt} [yellow][{_prompt_add}][/]"
+            _prompt_add = yellow(_prompt_add)
+    msg = prompt_msg(prompt, _prompt_add)
 
     while True:
         val = prompt_type.ask(
-            prompt,
+            msg,
             console=console,
             default=default_arg,
             show_default=show_default,
@@ -223,7 +231,7 @@ def bool_prompt(
         prompt = render_warning(prompt)
 
     return Confirm.ask(
-        prompt,
+        prompt_msg(),
         console=console,
         show_default=show_default,
         default=default,

--- a/harbor_cli/output/prompts.py
+++ b/harbor_cli/output/prompts.py
@@ -18,10 +18,11 @@ if TYPE_CHECKING:
     from ..config import HarborCLIConfig
     from ..state import State
 
-from ..style import STYLE_CLI_OPTION, render_warning
+from ..style import STYLE_CLI_OPTION
 from .console import console
 from .console import error
 from .console import exit
+from .console import warning
 from ..style.color import yellow
 from ..style.color import green
 from ..style import Icon
@@ -29,7 +30,7 @@ from .formatting.path import path_link
 
 
 def prompt_msg(*msgs: str) -> str:
-    return f"[bold]{green(Icon.PROMPT)} {' '.join(msgs)}[/bold]"
+    return f"[bold]{green(Icon.PROMPT)} {' '.join(msg.strip() for msg in msgs)}[/bold]"
 
 
 def str_prompt(
@@ -67,7 +68,7 @@ def str_prompt(
     # Notify user that a default secret will be used,
     # but don't actually show the secret
     if password and default not in (None, ..., ""):
-        _prompt_add = " (leave empty to use existing value)"
+        _prompt_add = "(leave empty to use existing value)"
     else:
         _prompt_add = ""
     msg = prompt_msg(prompt, _prompt_add)
@@ -227,11 +228,8 @@ def bool_prompt(
     warning: bool = False,
     **kwargs: Any,
 ) -> bool:
-    if warning:
-        prompt = render_warning(prompt)
-
     return Confirm.ask(
-        prompt_msg(),
+        prompt_msg(prompt),
         console=console,
         show_default=show_default,
         default=default,
@@ -301,10 +299,9 @@ def check_enumeration_options(
     limit: int | None = None,
 ) -> None:
     if state.config.general.confirm_enumeration and not limit and not query:
-        if not bool_prompt(
+        warning(
             f"Neither [{STYLE_CLI_OPTION}]--query[/] nor [{STYLE_CLI_OPTION}]--limit[/] is specified. "
             "This could result in a large amount of data being returned. "
-            "Do you want to continue?",
-            warning=True,
-        ):
+        )
+        if not bool_prompt("Continue?"):
             exit()

--- a/harbor_cli/output/render.py
+++ b/harbor_cli/output/render.py
@@ -161,5 +161,5 @@ def render_raw(result: Any, ctx: typer.Context | None = None, **kwargs: Any) -> 
         result = json.dumps(result)
         console.print_json(result, indent=state.config.output.JSON.indent)
     except Exception as e:
-        logger.warning("Unable to render raw data as JSON", exception=e)
+        logger.warning(f"Unable to render raw data as JSON: {e}")
         console.print(result)

--- a/harbor_cli/output/render.py
+++ b/harbor_cli/output/render.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from contextlib import nullcontext
 from typing import Any
-from typing import List
 from typing import Sequence
 from typing import TypeVar
 from typing import Union
@@ -17,6 +16,8 @@ from ..format import OutputFormat
 from ..logs import logger
 from ..state import get_state
 from .console import console
+from .console import info
+from .console import warning
 from .table import BuiltinTypeException
 from .table import EmptySequenceError
 from .table import get_renderable
@@ -129,13 +130,14 @@ def render_json(
     # data types, we wrap the data in a Pydantic model with a single field
     # named __root__, which renders the data as the root value of the JSON object:
     # Output(__root__={"foo": "bar"}).json() -> '{"foo": "bar"}'
-    # This is especially useful for serializing types like Paths and Timestamps.
+    # This is especially useful for serializing types like Paths and Timestamps,
+    # since they are not natively supported by the stdlib json module.
     #
     # In pydantic v2, the __root__ field is going away, and we will
     # be able to serialize/marshal any data type directly.
 
     class Output(BaseModel):
-        __root__: Union[T, List[T]]
+        __root__: Union[T, Sequence[T]]
 
     o = Output(__root__=result)
     o_json = o.json(indent=indent)
@@ -144,7 +146,7 @@ def render_json(
             raise OverwriteError(f"File {p.resolve()} exists.")
         with open(p, "w") as f:
             f.write(o_json)
-            logger.info(f"Output written to {p.resolve()}")
+            info(f"Output written to {p.resolve()}")
 
     # Print to stdout if no output file is specified or if the
     # --with-stdout flag is set.
@@ -161,5 +163,5 @@ def render_raw(result: Any, ctx: typer.Context | None = None, **kwargs: Any) -> 
         result = json.dumps(result)
         console.print_json(result, indent=state.config.output.JSON.indent)
     except Exception as e:
-        logger.warning(f"Unable to render raw data as JSON: {e}")
+        warning(f"Unable to render raw data as JSON: {e}")
         console.print(result)

--- a/harbor_cli/output/table/__init__.py
+++ b/harbor_cli/output/table/__init__.py
@@ -110,11 +110,11 @@ _RENDER_FUNCTIONS = [
 
 RENDER_FUNCTIONS = {}  # dict of functions + type of first argument
 for function in _RENDER_FUNCTIONS:
-    hints = typing.get_type_hints(function)
-    if not hints:
-        continue
-    val = next(iter(hints.values()))
     try:
+        hints = typing.get_type_hints(function)
+        if not hints:
+            continue
+        val = next(iter(hints.values()))
         RENDER_FUNCTIONS[val] = function
     except TypeError:
         logger.warning("Could not add render function %s", function)

--- a/harbor_cli/output/table/artifact.py
+++ b/harbor_cli/output/table/artifact.py
@@ -19,11 +19,7 @@ from rich.table import Table
 from ...harbor.artifact import get_artifact_architecture
 from ...harbor.artifact import get_artifact_severity
 from ...models import ArtifactVulnerabilitySummary
-from ...style import COLOR_CVE_CRITICAL
-from ...style import COLOR_CVE_HIGH
-from ...style import COLOR_CVE_LOW
-from ...style import COLOR_CVE_MEDIUM
-from ...style import get_severity_style
+from ...style.color import SeverityColor
 from ..formatting.builtin import bool_str
 from ..formatting.builtin import float_str
 from ..formatting.builtin import int_str
@@ -149,10 +145,9 @@ def artifact_vulnerabilities_table(
         report.sort()  # critical -> high -> medium -> low
         vulns = report.vulnerabilities
         for vulnerability in vulns:
-            sev_style = get_severity_style(vulnerability.severity)
             row = [
                 str_str(vulnerability.id),
-                f"[{sev_style}]{str_str(vulnerability.severity.value)}[/{sev_style}]",
+                SeverityColor.as_markup(vulnerability.severity),
                 float_str(vulnerability.get_cvss_score()),
                 str_str(vulnerability.package),
                 str_str(vulnerability.version),
@@ -194,10 +189,12 @@ def vuln_summary_table(summary: VulnerabilitySummary, **kwargs: Any) -> Table:
     )
     # NOTE: column is truncated if category has >9999 vulnerabilities, but that's unlikely
     col_kwargs = ColKwargs(min_width=5, max_width=5, justify="right")
-    table.add_column("Critical", style=f"black on {COLOR_CVE_CRITICAL}", **col_kwargs)
-    table.add_column("High", style=f"black on {COLOR_CVE_HIGH}", **col_kwargs)
-    table.add_column("Medium", style=f"black on {COLOR_CVE_MEDIUM}", **col_kwargs)
-    table.add_column("Low", style=f"black on {COLOR_CVE_LOW}", **col_kwargs)
+    table.add_column(
+        "Critical", style=f"black on {SeverityColor.CRITICAL}", **col_kwargs
+    )
+    table.add_column("High", style=f"black on {SeverityColor.HIGH}", **col_kwargs)
+    table.add_column("Medium", style=f"black on {SeverityColor.MEDIUM}", **col_kwargs)
+    table.add_column("Low", style=f"black on {SeverityColor.LOW}", **col_kwargs)
     # not adding unknown for now
     # TODO: add kwargs toggle for this
     # table.add_column("Unknown", style="black on grey")
@@ -226,7 +223,7 @@ def buildhistoryentry_table(
             datetime_str(entry.created),
             str_str(DOUBLE_SPACE_PATTERN.sub(" ", entry.created_by)),
         )
-        table.add_section()  # type: ignore # mypy thinks add_section doesn't exist(?)
+        table.add_section()
     return table
 
 

--- a/harbor_cli/output/table/project.py
+++ b/harbor_cli/output/table/project.py
@@ -15,6 +15,7 @@ from rich.table import Table
 
 from ...logs import logger
 from ...models import ProjectExtended
+from ..console import error
 from ..formatting.builtin import int_str
 from ..formatting.builtin import str_str
 from ..formatting.bytes import bytesize_str
@@ -30,7 +31,7 @@ def project_table(p: Sequence[Project], **kwargs: Any) -> Table:
     """Display one or more projects in a table."""
     table = get_table("Project", p)
     table.add_column("ID")
-    table.add_column("Name")
+    table.add_column("Name", overflow="fold")
     table.add_column("Public")
     table.add_column("Repositories")
     table.add_column("Created")
@@ -49,7 +50,7 @@ def project_table(p: Sequence[Project], **kwargs: Any) -> Table:
 
 def project_extended_panel(p: Sequence[ProjectExtended], **kwargs: Any) -> Panel:
     """Display extended information about one or more projects."""
-    if len(p) > 1:
+    if len(p) != 1:
         logger.warning("This function should only be used to display a single project.")
     pt_table = project_extended_table(p)
     pmt_table = project_metadata_table([p.metadata for p in p if p.metadata])
@@ -138,7 +139,7 @@ def _get_quota(resource: ResourceList | None) -> int | None:
             assert isinstance(quota, int)
     except (AttributeError, AssertionError) as e:
         if isinstance(e, AssertionError):
-            logger.error(f"Resource quota is not an integer: {quota}")
+            error(f"Resource quota is not an integer: {quota}")
         quota = None
     return quota
 

--- a/harbor_cli/output/table/registry.py
+++ b/harbor_cli/output/table/registry.py
@@ -22,7 +22,7 @@ def registryproviders_table(
     providers: Sequence[RegistryProviders], **kwargs: Any
 ) -> Table:
     """Renders a list of RegistryProvider objects as individual tables in a panel."""
-    if len(providers) > 1:
+    if len(providers) != 1:
         logger.warning("Can only display one list of registry providers at a time")
     prov = providers[0]
     table = get_table("Registry Providers", columns=["Name", "Info"], show_lines=True)

--- a/harbor_cli/output/table/search.py
+++ b/harbor_cli/output/table/search.py
@@ -18,7 +18,7 @@ from .project import project_table
 
 def search_panel(search: Sequence[Search], **kwargs: Any) -> Panel:
     """Display one or more repositories in a table."""
-    if len(search) > 1:
+    if len(search) != 1:
         logger.warning("Can only display one search result at a time.")
     s = search[0]  # guaranteed to be at least one result
 

--- a/harbor_cli/output/table/system.py
+++ b/harbor_cli/output/table/system.py
@@ -14,7 +14,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from ...logs import logger
-from ...style import get_health_color
+from ...style.color import HealthColor
 from ..formatting.builtin import bool_str
 from ..formatting.builtin import int_str
 from ..formatting.builtin import str_str
@@ -27,7 +27,7 @@ from ._utils import get_table
 # GeneralInfo is the model used for general system info.
 def systeminfo_table(systeminfo: Sequence[SystemInfo], **kwargs: Any) -> Table:
     """Display system info in a table."""
-    if len(systeminfo) > 1:
+    if len(systeminfo) != 1:
         # should never happen
         logger.warning("Can only display one system info at a time.")
     info = systeminfo[0]
@@ -59,7 +59,7 @@ def systeminfo_table(systeminfo: Sequence[SystemInfo], **kwargs: Any) -> Table:
 
 def overallhealthstatus_panel(health: OverallHealthStatus, **kwargs) -> Panel:
     # Show overall health status at the top
-    status_color = get_health_color(health.status)
+    status_color = HealthColor.from_health(health.status)
     status = f"[{status_color}]{health.status}[/]"
     status_table = Table.grid()
     status_table.add_row("Status: ", status)

--- a/harbor_cli/state.py
+++ b/harbor_cli/state.py
@@ -11,6 +11,8 @@ from harborapi import HarborAsyncClient
 from pydantic import BaseModel
 from rich.console import Console
 
+from .output.console import warning
+
 # This module generally shouldn't import from other local modules
 # because it's widely used throughout the application, and we don't want
 # to create circular import issues. It sucks, but it's the way it is.
@@ -184,16 +186,15 @@ class State:
         """
         from .harbor.common import prompt_url
         from .harbor.common import prompt_username_secret
-        from .logs import logger
 
         if not self.config.harbor.url:
-            logger.warning("Harbor API URL missing from configuration file.")
+            warning("Harbor API URL missing from configuration file.")
             self.config.harbor.url = prompt_url()
 
         # We need one of the available auth methods to be specified
         # If not, prompt for username and password
         if not self.config.harbor.has_auth_method:
-            logger.warning(
+            warning(
                 "Harbor authentication method is missing or incomplete in configuration file."
             )
             username, secret = prompt_username_secret(

--- a/harbor_cli/state.py
+++ b/harbor_cli/state.py
@@ -11,8 +11,6 @@ from harborapi import HarborAsyncClient
 from pydantic import BaseModel
 from rich.console import Console
 
-from .output.console import warning
-
 # This module generally shouldn't import from other local modules
 # because it's widely used throughout the application, and we don't want
 # to create circular import issues. It sucks, but it's the way it is.
@@ -186,6 +184,10 @@ class State:
         """
         from .harbor.common import prompt_url
         from .harbor.common import prompt_username_secret
+        from .style.style import render_cli_command
+        from .style.style import render_cli_option
+        from .style.style import render_cli_value
+        from .output.console import warning
 
         if not self.config.harbor.url:
             warning("Harbor API URL missing from configuration file.")
@@ -203,6 +205,11 @@ class State:
             )
             self.config.harbor.username = username
             self.config.harbor.secret = secret  # type: ignore # pydantic.SecretStr
+            warning(
+                "Authentication info updated. "
+                f"Run {render_cli_command('harbor init')} to configure it permanently. "
+                f"Suppress this warning by setting {render_cli_option('general.warnings')} to {render_cli_value('false')}."
+            )
 
         self.authenticate_harbor()
 

--- a/harbor_cli/style/__init__.py
+++ b/harbor_cli/style/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from . import *
+from .color import *
 from .markup import *
 from .style import *

--- a/harbor_cli/style/color.py
+++ b/harbor_cli/style/color.py
@@ -28,6 +28,10 @@ def yellow(message: str) -> str:
     return f"[yellow]{message}[/]"
 
 
+def bold(message: str) -> str:
+    return f"[bold]{message}[/]"
+
+
 class HealthColor(StrEnum):
     HEALTHY = "green"
     UNHEALTHY = "red"

--- a/harbor_cli/style/color.py
+++ b/harbor_cli/style/color.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from harborapi.models.scanner import Severity
+from strenum import StrEnum
+
+
+def blue(message: str) -> str:
+    return f"[blue]{message}[/]"
+
+
+def cyan(message: str) -> str:
+    return f"[cyan]{message}[/]"
+
+
+def green(message: str) -> str:
+    return f"[green]{message}[/]"
+
+
+def magenta(message: str) -> str:
+    return f"[magenta]{message}[/]"
+
+
+def red(message: str) -> str:
+    return f"[red]{message}[/]"
+
+
+def yellow(message: str) -> str:
+    return f"[yellow]{message}[/]"
+
+
+class HealthColor(StrEnum):
+    HEALTHY = "green"
+    UNHEALTHY = "red"
+
+    @classmethod
+    def from_health(cls, health: str | None) -> str:
+        if health == "healthy":
+            return HealthColor.HEALTHY
+        else:
+            return HealthColor.UNHEALTHY
+
+
+class SeverityColor(StrEnum):
+    CRITICAL = "dark_red"
+    HIGH = "red"
+    MEDIUM = "orange3"
+    LOW = "green"
+    NEGLIGIBLE = "blue"
+    NONE = "white"
+    UNKNOWN = "white"
+
+    @classmethod
+    def from_severity(cls, severity: str | Severity) -> str:
+        """Return the color for the given severity level."""
+        if isinstance(severity, Severity):
+            severity = severity.value
+        try:
+            color = getattr(cls, severity.upper())
+            if isinstance(color, SeverityColor):
+                return color
+            raise ValueError(f"Invalid severity: {severity}")
+        except (AttributeError, ValueError):
+            return SeverityColor.UNKNOWN
+
+    @classmethod
+    def as_markup(cls, severity: str | Severity) -> str:
+        """Return the given severity as a Rich markup-formatted string."""
+        color = cls.from_severity(severity)
+        return f"[{color}]{severity}[/]"

--- a/harbor_cli/style/style.py
+++ b/harbor_cli/style/style.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from harborapi.models.scanner import Severity
+from strenum import StrEnum
+
 
 STYLE_CONFIG_OPTION = "italic yellow"
 """Used to signify a configuration file option/key/entry."""
@@ -25,34 +26,26 @@ STYLE_WARNING = "yellow"
 EMOJI_YES = ":white_check_mark:"
 EMOJI_NO = ":cross_mark:"
 
-
+####################
 # Colors
+####################
 # Colors should be used to colorize output and help define styles,
 # but they should not contain any formatting (e.g. bold, italic, `x` on `y`, etc.)
-COLOR_CVE_CRITICAL = "dark_red"
-COLOR_CVE_HIGH = "red"
-COLOR_CVE_MEDIUM = "orange3"
-COLOR_CVE_LOW = "green"
-COLOR_CVE_NEGLIGIBLE = "blue"
-COLOR_CVE_UNKNOWN = "white"
-COLOR_HEALTH_HEALTHY = "green"
-COLOR_HEALTH_UNHEALTHY = "red"
+####################
 
 
-STYLE_CVE_SEVERITY = {
-    "critical": COLOR_CVE_CRITICAL,
-    "high": COLOR_CVE_HIGH,
-    "medium": COLOR_CVE_MEDIUM,
-    "low": COLOR_CVE_LOW,
-    "negligible": COLOR_CVE_NEGLIGIBLE,
-    "unknown": COLOR_CVE_UNKNOWN,
-}
+class Icon(StrEnum):
+    INFO = "!"
+    OK = "✓"
+    ERROR = "✗"
+    PROMPT = "?"
+    WARNING = "⚠"
 
 
-def get_severity_style(severity: str | Severity) -> str:
-    if isinstance(severity, Severity):
-        severity = severity.value.lower()
-    return STYLE_CVE_SEVERITY.get(severity, "white")
+# TODO: replace all use of constants with these enums
+class Emoji(StrEnum):
+    YES = EMOJI_YES
+    NO = EMOJI_NO
 
 
 def render_warning(msg: str) -> str:
@@ -82,12 +75,3 @@ def render_cli_command(value: str) -> str:
 def help_config_override(option: str) -> str:
     """Render a help string for a configuration file option/key/entry."""
     return f"Overrides config option {render_config_option(option)}."
-
-
-def get_health_color(health: str | None) -> str:
-    # health status can be "healthy" and "unhealthy"
-    # but we treat anything other than "healthy" as unhealthy
-    if health == "healthy":
-        return COLOR_HEALTH_HEALTHY
-    else:
-        return COLOR_HEALTH_UNHEALTHY

--- a/harbor_cli/utils/keyring.py
+++ b/harbor_cli/utils/keyring.py
@@ -30,10 +30,12 @@ def keyring_supported():
         if password == dummy_password:
             return True
         else:
-            raise keyring.errors.KeyringError
+            raise keyring.errors.KeyringError(
+                "Keyring backend did not return the correct password."
+            )
     # TODO: make this error handling more robust. Differentiate between different
     # keyring errors and handle them accordingly.
-    except keyring.errors.KeyringError as e:
+    except (keyring.errors.KeyringError, KeyringUnsupportedError) as e:
         logger.debug(f"Keyring is not supported on this platform: {e}", exc_info=True)
         return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "tomli-w>=1.0.0",
   "rich>=12.6.0",
   "shellingham>=1.5.0",
-  "loguru>=0.6.0",
   "click-repl>=0.2.0",
   "fuzzywuzzy>=0.18.0",
   "python-Levenshtein>=0.20.9",
@@ -74,6 +73,7 @@ dependencies = [
   "black>=22.10.0",
   "hypothesis>=6.62.1",
   "ruff>=0.0.275",
+  "freezegun>=1.2.2",
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "python-Levenshtein>=0.20.9",
   "keyring>=24.2.0",
   "httpx[socks]",
+  "strenum>=0.4.15",
 ]
 dynamic = ["version", "readme"]
 

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -6,20 +6,23 @@ basicauth = ""
 credentials_file = ""
 validate_data = true
 raw_mode = false
+verify_ssl = true
+keyring = false
+
+[harbor.retry]
+enabled = true
+max_tries = 5
+max_time = 10.0
 
 [general]
 confirm_deletion = true
-
-[logging]
-enabled = true
-structlog = false
-level = "INFO"
+confirm_enumeration = true
+warnings = true
 
 [output]
 format = "table"
 paging = false
 pager = ""
-confirm_enumeration = true
 
 [output.table]
 description = false
@@ -35,7 +38,24 @@ footer = ""
 caption = ""
 expand = true
 show_header = true
+bool_emoji = false
 
 [output.JSON]
 indent = 2
-sort_keys = true
+sort_keys = false
+
+[repl]
+history = true
+history_file = "/Users/pederhan/Library/Application Support/harbor-cli/history"
+
+[cache]
+enabled = false
+ttl = 300
+
+[logging]
+enabled = true
+level = "WARNING"
+directory = "/Users/pederhan/Library/Logs/harbor-cli"
+filename = "harbor_cli-{time}.log"
+timeformat = "%Y-%m-%d"
+retention = 30

--- a/tests/commands/cli/test_cli_config.py
+++ b/tests/commands/cli/test_cli_config.py
@@ -65,10 +65,10 @@ def test_cli_config_get(
     assert stdout_config == config
 
 
-def test_env_no_vars(invoke, caplog: LogCaptureFixture) -> None:
+def test_env_no_vars(invoke) -> None:
     res = invoke(["cli-config", "env"], env={})  # unset all env vars for this test
     assert res.exit_code == 0
-    assert "No environment variables set" in caplog.text
+    assert "No environment variables set" in res.stderr
 
 
 def test_env_var_set(invoke) -> None:

--- a/tests/commands/cli/test_cli_config.py
+++ b/tests/commands/cli/test_cli_config.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from pytest import LogCaptureFixture
+
 from harbor_cli.config import EnvVar
 from harbor_cli.config import HarborCLIConfig
 
@@ -63,10 +65,10 @@ def test_cli_config_get(
     assert stdout_config == config
 
 
-def test_env_no_vars(invoke) -> None:
+def test_env_no_vars(invoke, caplog: LogCaptureFixture) -> None:
     res = invoke(["cli-config", "env"], env={})  # unset all env vars for this test
     assert res.exit_code == 0
-    assert "No environment variables set" in res.stderr
+    assert "No environment variables set" in caplog.text
 
 
 def test_env_var_set(invoke) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,7 @@ from typing import Protocol
 import click
 import pytest
 import typer
-from _pytest.logging import LogCaptureFixture
 from harborapi import HarborAsyncClient
-from loguru import logger
 from typer.testing import CliRunner
 from typer.testing import Result
 
@@ -24,7 +22,7 @@ from harbor_cli.config import EnvVar
 from harbor_cli.config import HarborCLIConfig
 from harbor_cli.format import OutputFormat
 from harbor_cli.main import app as main_app
-from harbor_cli.utils.keyring import KEYRING_SUPPORTED
+from harbor_cli.utils.keyring import keyring_supported
 
 runner = CliRunner(mix_stderr=False)
 
@@ -131,16 +129,9 @@ def revert_state_config(state: state.State) -> Generator[None, None, None]:
     state.config = original_config
 
 
-@pytest.fixture
-def caplog(caplog: LogCaptureFixture):
-    handler_id = logger.add(caplog.handler, format="{message}")
-    yield caplog
-    logger.remove(handler_id)
-
-
 requires_keyring = pytest.mark.skipif(
-    not KEYRING_SUPPORTED, reason="Keyring is not supported on this platform."
+    not keyring_supported(), reason="Keyring is not supported on this platform."
 )
 requires_no_keyring = pytest.mark.skipif(
-    KEYRING_SUPPORTED, reason="Test requires keyring to be unsupported."
+    keyring_supported(), reason="Test requires keyring to be unsupported."
 )

--- a/tests/output/test_console.py
+++ b/tests/output/test_console.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from typing import Callable
+
+import pytest
+from pytest import CaptureFixture
+from pytest import LogCaptureFixture
+
+from harbor_cli.config import LoggingSettings
+from harbor_cli.logs import LogLevel
+from harbor_cli.logs import update_logging
+from harbor_cli.output.console import error
+from harbor_cli.output.console import info
+from harbor_cli.output.console import success
+from harbor_cli.output.console import warning
+from harbor_cli.state import State
+
+
+def _configure_logging(
+    settings: LoggingSettings, level: LogLevel, tmp_path: Path
+) -> None:
+    """Configure logging for the CLI."""
+    settings.level = level
+    settings.directory = tmp_path / "logs" / level.value.lower()
+    settings.directory.mkdir(parents=True, exist_ok=True)
+    update_logging(settings)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def revert_logging(state: State) -> None:
+    """Revert logging to the default settings after each test."""
+    settings_pre = state.config.logging.copy()
+    yield
+    update_logging(settings_pre)
+
+
+console_funcs = {
+    # LogLevel.NOTSET: info,
+    LogLevel.DEBUG: success,
+    LogLevel.INFO: info,
+    # LogLevel.WARN: warning,
+    LogLevel.WARNING: warning,
+    LogLevel.ERROR: error,
+    # LogLevel.FATAL: error,
+    # LogLevel.CRITICAL: error,
+}
+
+
+@pytest.mark.parametrize(
+    "level,func",
+    [
+        # (LogLevel.NOTSET, info), # NYI
+        (LogLevel.DEBUG, success),
+        (LogLevel.INFO, info),
+        # (LogLevel.WARN, warning),
+        (LogLevel.WARNING, warning),
+        (LogLevel.ERROR, error),
+        # (LogLevel.FATAL, error), # NYI
+        # (LogLevel.CRITICAL, critical), # NYI
+    ],
+)
+def test_loglevels(
+    state: State,
+    capsys: CaptureFixture,
+    caplog: LogCaptureFixture,
+    tmp_path: Path,
+    level: LogLevel,
+    func: Callable[..., Any],
+) -> None:
+    """Tests that the logging performed by the console functions is correct,
+    i.e. log levels are respected, the correct message is logged, and the
+    file is in the expected location."""
+
+    # Test logging with a level that matches the function
+    _configure_logging(state.config.logging, level, tmp_path)
+    test_str = f"testing {str(level.name).lower()}"
+    func(test_str)
+    captured = capsys.readouterr()
+    assert test_str in captured.err
+    assert len(caplog.records) == 1
+    assert test_str in caplog.records[0].message
+    assert test_str in state.config.logging.path.read_text()
+
+    # Ensure that the log level is respected when level exceeds the function
+    # i.e. calling info(...) when level is WARNING should not log to file, etc.
+    for lvl in LogLevel:
+        if lvl.as_int() <= level.as_int():
+            continue
+        _configure_logging(state.config.logging, lvl, tmp_path)
+        test_str = f"Exceeded ({str(lvl.name).lower()} > {str(level.name).lower()})"
+        func(test_str)
+        captured = capsys.readouterr()
+        assert test_str in captured.err
+        assert test_str in caplog.text
+        # Should not be logged to file
+        assert test_str not in state.config.logging.path.read_text()

--- a/tests/output/test_prompts.py
+++ b/tests/output/test_prompts.py
@@ -17,7 +17,10 @@ from pytest import MonkeyPatch
 from harbor_cli.output.prompts import float_prompt
 from harbor_cli.output.prompts import int_prompt
 from harbor_cli.output.prompts import path_prompt
+from harbor_cli.output.prompts import prompt_msg
 from harbor_cli.output.prompts import str_prompt
+from harbor_cli.style.color import green
+from harbor_cli.style.style import Icon
 
 # TODO: test defaults
 
@@ -134,3 +137,17 @@ def test_path_prompt(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     p = p.resolve().absolute()
     monkeypatch.setattr("sys.stdin", io.StringIO(f"{p}\n"))
     assert path_prompt("foo") == p
+
+
+@pytest.mark.parametrize(
+    "inp, expected",
+    [
+        (("foo",), "foo"),
+        (("foo", "bar"), "foo bar"),
+        (("foo", "bar", "baz", "gux"), "foo bar baz gux"),
+        (("foo", ""), "foo"),
+        (("foo", None), "foo"),
+    ],
+)
+def test_prompt_msg(inp: tuple[str, ...], expected: str) -> None:
+    assert prompt_msg(*inp) == f"[bold]{green(Icon.PROMPT)} {expected}[/bold]"

--- a/tests/output/test_prompts.py
+++ b/tests/output/test_prompts.py
@@ -12,6 +12,7 @@ from hypothesis import HealthCheck
 from hypothesis import settings
 from hypothesis import strategies as st
 from pytest import CaptureFixture
+from pytest import LogCaptureFixture
 from pytest import MonkeyPatch
 
 from harbor_cli.output.prompts import float_prompt
@@ -113,7 +114,10 @@ def test_float_prompt(
 @pytest.mark.timeout(1)
 @pytest.mark.parametrize("leading_newline", leading_newline())
 def test_float_prompt_nan(
-    monkeypatch: MonkeyPatch, leading_newline: str, capsys: CaptureFixture
+    monkeypatch: MonkeyPatch,
+    leading_newline: str,
+    capsys: CaptureFixture,
+    caplog: LogCaptureFixture,
 ) -> None:
     # if we give it a nan, it will prompt for new input
     # so we need to give it a valid input after that
@@ -121,7 +125,7 @@ def test_float_prompt_nan(
     monkeypatch.setattr("sys.stdin", io.StringIO(stdin_str))
     assert float_prompt("foo") == 0.0
     stdout, stderr = capsys.readouterr()
-    assert "NaN" in stderr
+    assert "NaN" in caplog.text
     if leading_newline:
         # Rich prints this message to stdout for some reason
         assert "Please enter a number" in stdout

--- a/tests/output/test_prompts.py
+++ b/tests/output/test_prompts.py
@@ -12,7 +12,6 @@ from hypothesis import HealthCheck
 from hypothesis import settings
 from hypothesis import strategies as st
 from pytest import CaptureFixture
-from pytest import LogCaptureFixture
 from pytest import MonkeyPatch
 
 from harbor_cli.output.prompts import float_prompt
@@ -117,7 +116,6 @@ def test_float_prompt_nan(
     monkeypatch: MonkeyPatch,
     leading_newline: str,
     capsys: CaptureFixture,
-    caplog: LogCaptureFixture,
 ) -> None:
     # if we give it a nan, it will prompt for new input
     # so we need to give it a valid input after that
@@ -125,7 +123,7 @@ def test_float_prompt_nan(
     monkeypatch.setattr("sys.stdin", io.StringIO(stdin_str))
     assert float_prompt("foo") == 0.0
     stdout, stderr = capsys.readouterr()
-    assert "NaN" in caplog.text
+    assert "NaN" in stderr
     if leading_newline:
         # Rich prints this message to stdout for some reason
         assert "Please enter a number" in stdout

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,10 +30,6 @@ def test_envvars(
         assert res.exit_code == 0
         return res
 
-    # FIXME HACK: for some reason this test makes permanent changes to the config
-    # despite the fact that we have a fixture that is supposed to reset it
-    # between tests.
-
     inv(EnvVar.URL, "https://example.com/api/v2.0")
     assert state.config.harbor.url == "https://example.com/api/v2.0"
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,11 @@ from harbor_cli.state import State
 
 
 def test_envvars(
-    invoke: PartialInvoker, app: typer.Typer, tmp_path: Path, state: State
+    invoke: PartialInvoker,
+    app: typer.Typer,
+    tmp_path: Path,
+    state: State,
+    config_file: Path,
 ) -> None:
     @app.command("test-cmd")
     def test_cmd(ctx: typer.Context) -> None:
@@ -20,7 +24,9 @@ def test_envvars(
         return 0
 
     def inv(envvar: EnvVar, value: str) -> Result:
-        res = invoke(["test-cmd"], env={str(envvar): value})
+        res = invoke(
+            ["test-cmd"], env={str(envvar): value, str(EnvVar.CONFIG): str(config_file)}
+        )
         assert res.exit_code == 0
         return res
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -149,14 +149,18 @@ def test_harbor_is_authable_keyring() -> None:
 
 
 @requires_no_keyring
-def test_harbor_is_authable_no_keyring() -> None:
-    with pytest.raises(keyring.errors.KeyringError) as exc_info:
-        h = HarborSettings(username="admin", secret="ignored", keyring=True)
-        h.secret_value  # raises
-    assert "not supported" in str(exc_info.value).casefold()
-    h = HarborSettings(username="admin", secret="password", keyring=False)
-    assert h.secret_value == "password"
+def test_harbor_is_authable_no_keyring(caplog: pytest.LogCaptureFixture) -> None:
+    h = HarborSettings(username="admin", secret="fallback", keyring=True)
+    assert keyring is True
+    # By accessing the secret_value property when keyring is unsupported,
+    # it will fall back on the secret field and also set `keyring` to False
+    # so that it will not retry the keyring again in REPL mode
+    assert h.secret_value == "fallback"
+    assert h.keyring is False
+    assert "supported" in caplog.text.lower()
     assert h.has_auth_method
+    assert h.credentials["username"] == "admin"
+    assert h.credentials["secret"] == "fallback"
 
 
 def test_harbor_is_authable_basicauth() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,7 +151,7 @@ def test_harbor_is_authable_keyring() -> None:
 @requires_no_keyring
 def test_harbor_is_authable_no_keyring(caplog: pytest.LogCaptureFixture) -> None:
     h = HarborSettings(username="admin", secret="fallback", keyring=True)
-    assert keyring is True
+    assert h.keyring is True
     # By accessing the secret_value property when keyring is unsupported,
     # it will fall back on the secret field and also set `keyring` to False
     # so that it will not retry the keyring again in REPL mode

--- a/tests/test_keyring.py
+++ b/tests/test_keyring.py
@@ -6,6 +6,7 @@ import pytest
 from .conftest import requires_keyring
 from .conftest import requires_no_keyring
 from harbor_cli.utils.keyring import get_password
+from harbor_cli.utils.keyring import KeyringUnsupportedError
 from harbor_cli.utils.keyring import set_password
 
 
@@ -24,13 +25,13 @@ def test_get_password():
 
 @requires_no_keyring
 def test_set_password_no_keyring():
-    with pytest.raises(keyring.errors.KeyringError) as exc_info:
+    with pytest.raises(KeyringUnsupportedError) as exc_info:
         set_password("harbor_cli_test_user", "harbor_cli_test_password")
     assert "not supported" in str(exc_info.value)
 
 
 @requires_no_keyring
 def test_get_password_no_keyring():
-    with pytest.raises(keyring.errors.KeyringError) as exc_info:
+    with pytest.raises(KeyringUnsupportedError) as exc_info:
         get_password("harbor_cli_test_user")
     assert "not supported" in str(exc_info.value)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 import logging
+import os
+from pathlib import Path
 
+from harbor_cli.config import HarborCLIConfig
+from harbor_cli.logs import disable_logging
+from harbor_cli.logs import logger
 from harbor_cli.logs import LogLevel
+from harbor_cli.logs import replace_handler
+from harbor_cli.logs import setup_logging
+from harbor_cli.logs import update_logging
 
 
 def test_log_level_as_int() -> None:
@@ -14,3 +22,45 @@ def test_log_level_as_int() -> None:
     assert LogLevel.ERROR.as_int() == logging.ERROR
     assert LogLevel.FATAL.as_int() == logging.FATAL
     assert LogLevel.CRITICAL.as_int() == logging.CRITICAL
+
+
+def test_setup_logging(config: HarborCLIConfig) -> None:
+    disable_logging()
+    assert not logger.handlers
+    setup_logging(config.logging)
+    assert logger.handlers
+    handler = logger.handlers[0]
+    assert handler.level == config.logging.level.as_int()
+    # TODO: test filename
+
+
+def test_update_logging(config: HarborCLIConfig, tmp_path: Path) -> None:
+    logging_settings_pre = config.logging.copy()
+    config.logging.level = LogLevel.WARNING
+    config.logging.directory = tmp_path / "test_update_logging"
+    config.logging.directory.mkdir(parents=True, exist_ok=True)
+
+    # Update logging settings
+    update_logging(config.logging)
+    assert logger.handlers
+
+    # Check that the handler was updated
+    handler = logger.handlers[0]
+    assert handler.level == config.logging.level.as_int()
+    assert handler.baseFilename == os.path.abspath(config.logging.path)
+
+    # Revert logging settings
+    update_logging(logging_settings_pre)
+
+
+def test_disable_logging(config: HarborCLIConfig) -> None:
+    # Call disable_logging() twice to ensure it doesn't raise an exception
+    disable_logging()
+    disable_logging()
+    assert not logger.handlers
+
+    # Re-enable logging and then disable again
+    setup_logging(config.logging)
+    assert logger.handlers
+    disable_logging()
+    assert not logger.handlers

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import logging
+
+from harbor_cli.logs import LogLevel
+
+
+def test_log_level_as_int() -> None:
+    assert LogLevel.NOTSET.as_int() == logging.NOTSET
+    assert LogLevel.DEBUG.as_int() == logging.DEBUG
+    assert LogLevel.INFO.as_int() == logging.INFO
+    assert LogLevel.WARN.as_int() == logging.WARN
+    assert LogLevel.WARNING.as_int() == logging.WARNING
+    assert LogLevel.ERROR.as_int() == logging.ERROR
+    assert LogLevel.FATAL.as_int() == logging.FATAL
+    assert LogLevel.CRITICAL.as_int() == logging.CRITICAL


### PR DESCRIPTION
This PR removes the Loguru dependency and instead performs all logging via the standard library logging module. The logger only logs to a file specified in the config with `logging.directory` and `logging.filename`. The option `logging.level` controls the verbosity of the log file. As part of this change, the default log level is now `WARNING` (was `INFO`). This means information and success messages are not logged to the log file by default.

Furthermore, the functions `success()`, `info()`, `warning()` and `error()` now display the messages via the default stderr Rich console, as well as logging the same message with the corresponding log level (`success()` is equivalent to `DEBUG`).

A new config option `general.warnings` controls whether or not warnings are displayed to the user.

----

## New terminal message style

The whole messaging system has also gotten a facelift and now displays all text in the default terminal color, while using color coded unicode symbols as prefixes to denote the type of message shown (information, success, warning, error, etc.). 

This new messaging format is pretty much ripped off from GitHub CLI, because it's just an elegant way of doing things, and I'd rather not reinvent the wheel on the design front.

<img width="457" alt="image" src="https://github.com/pederhan/harbor-cli/assets/107681714/2d89e267-5656-480f-9131-702b920db826">

**Changes:**

* Success messages are now prefixed by a green `✓` symbol and logged with a level of `DEBUG`.
* Informational messages are now prefixed by a green `!` symbol and logged with a level of `INFO`.
* Warning messages are now displayed in bold and prefixed by a yellow `⚠` symbol and logged with a level of `WARNING`.
* Error messages are now prefixed by a red `✗` symbol and logged with a level of `ERROR`.
* Prompts are now displayed in bold and prefixed by a green `?` symbol. Prompts are not logged (should they be?).

